### PR TITLE
Hot fix guard lost

### DIFF
--- a/src/api/shadow.rs
+++ b/src/api/shadow.rs
@@ -45,7 +45,7 @@ impl Shadow {
     /// Get mmr
     pub async fn get_mmr_root(&self, leaf_index: usize) -> Result<MMRRoot> {
         let block_number = leaf_index + 1;
-        let url = &format!("{}/ethereum/parent_mmr_root/{}", &self.api, block_number);
+        let url = &format!("{}/ethereum/mmr_root/{}", &self.api, block_number);
         let resp = self
             .http
             .get(url)


### PR DESCRIPTION
May be due to the fact that the guard did not succeed when executing the transaction through proxy, and without raising an err. In this case, this pending block will be regarded as successful and will be placed in the local voted list, so the vote will not be exec next time.

**_important: This hotfix set back to use old shadow which has no API `parent_mmr_root`_**