### PR TITLE
chore: upgrade jsonrpsee ws client to fix wrong report error on valid ws address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ path = "src/bin/bridger.rs"
 
 [dependencies]
 jsonrpsee-types = "0.2.0-alpha.2"
-jsonrpsee-ws-client = "0.2.0-alpha.2"
+jsonrpsee-ws-client = "0.2.0-alpha.3"
 jsonrpsee-http-client = "0.2.0-alpha.2"
 async-macros = "2.0.0"
 async-trait = "0.1.40"

--- a/darwinia/Cargo.toml
+++ b/darwinia/Cargo.toml
@@ -13,7 +13,7 @@ features = ["derive"]
 
 [dependencies]
 jsonrpsee-types = "0.2.0-alpha.2"
-jsonrpsee-ws-client = "0.2.0-alpha.2"
+jsonrpsee-ws-client = "0.2.0-alpha.3"
 jsonrpsee-http-client = "0.2.0-alpha.2"
 serde_json = "1.0"
 thiserror = "1.0.20"


### PR DESCRIPTION
the lower version of jsonrpsee client will report an error when connecting to `pc2-rpc-xxx` ws address.

upgrade jsonrpsee-ws-client from 0.2.0-alpha.2 to 0.2.0-alpha.3
```toml
[dependencies]
jsonrpsee-ws-client = "0.2.0-alpha.3"
jsonrpsee-types = "0.2.0-alpha.2"
[dependencies.tokio]
package = "tokio"
version = "0.2.22"
features = ["full"]
```
only need to upgrade ws client