### PR TITLE
Fix overwrite `RUST_LOG` in env

### DIFF
--- a/bin/src/initialize.rs
+++ b/bin/src/initialize.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use bridge_traits::bridge::task::BridgeSand;
 use linked_darwinia::task::DarwiniaLinked;
 use task_darwinia_ethereum::task::DarwiniaEthereumTask;
@@ -11,24 +13,26 @@ pub fn init() -> anyhow::Result<()> {
 }
 
 fn init_log() {
-    if let Err(_) = std::env::var("RUST_LOG") {
-        std::env::set_var(
+    if env::var("RUST_LOG").is_err() {
+        env::set_var(
             "RUST_LOG",
-            r#"
-        serde=info,
-        lifeline=debug,
-        darwinia_bridge=debug,
-        bridge=info,
-        support_tracker_evm_log=info,
-        task-darwinia-ethereum=trace,
-        task-pangolin-ropsten=trace,
-        task-pangolin-pangoro=trace,
-        "#,
+            [
+                "serde=info",
+                "lifeline=debug",
+                "darwinia_bridge=debug",
+                "bridge=info",
+                "support_tracker_evm_log=info",
+                "task-darwinia-ethereum=trace",
+                "task-pangolin-ropsten=trace",
+                "task-pangolin-pangoro=trace",
+            ]
+            .join(","),
         );
     }
-    if let Err(_) = std::env::var("RUST_BACKTRACE") {
-        std::env::set_var("RUST_BACKTRACE", "1");
+    if env::var("RUST_BACKTRACE").is_err() {
+        env::set_var("RUST_BACKTRACE", "1");
     }
+
     env_logger::init();
 }
 


### PR DESCRIPTION
https://github.com/darwinia-network/bridger/issues/301


```
$ export RUST_LOG=bridge=debug
$ ./target/debug/bridger.exe server --base-path=/data/darwinia-network/_data/bridger
[2021-10-28T14:17:55Z INFO  bridger::handler::handle_server] bridger is running on: 127.0.0.1:1098
[2021-10-28T14:18:00Z INFO  task_pangolin_pangoro::chains::pangolin::s2s_messages] Starting pangolin -> pangoro messages relay.
```
