### PR TITLE
Add missing type size for `SpecVersion`

### DIFF
--- a/components/client-pangolin-subxt/src/darwinia/runtime.rs
+++ b/components/client-pangolin-subxt/src/darwinia/runtime.rs
@@ -51,6 +51,7 @@ impl Runtime for DarwiniaRuntime {
         registry.register_type_size::<u128>("RingBalance");
         registry.register_type_size::<u128>("KtonBalance");
         registry.register_type_size::<u128>("Fee");
+        registry.register_type_size::<u32>("SpecVersion");
         registry.register_type_size::<[u8; 4]>("ChainId");
         registry.register_type_size::<[u8; 16]>("BridgeMessageId");
         registry.register_type_size::<[u8; 20]>("EthereumAddress");


### PR DESCRIPTION


```
[2021-11-01T08:50:59Z ERROR task_pangolin_ropsten::service::pangolin] An error occurred while processing the events of block 1100616: Type size unavailable while decoding event: "SpecVersion"
    
    Stack backtrace:
       0: task_pangolin_ropsten::service::pangolin::DarwiniaServiceRunner::start::{{closure}}
       1: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
       2: <lifeline::spawn::LifelineFuture<F> as core::future::future::Future>::poll
       3: tokio::runtime::task::harness::Harness<T,S>::poll
       4: std::thread::local::LocalKey<T>::with
       5: tokio::runtime::thread_pool::worker::Context::run_task
       6: tokio::runtime::thread_pool::worker::Context::run
       7: tokio::macros::scoped_tls::ScopedKey<T>::set
       8: tokio::runtime::thread_pool::worker::run
       9: tokio::runtime::task::core::CoreStage<T>::poll
      10: tokio::runtime::task::harness::Harness<T,S>::poll
      11: std::sys_common::backtrace::__rust_begin_short_backtrace
      12: core::ops::function::FnOnce::call_once{{vtable.shim}}
      13: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
                 at ./rustc/b849326744a8eec939e592f0ab13bff85cc865d3/library/alloc/src/boxed.rs:1546:9
          <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
                 at ./rustc/b849326744a8eec939e592f0ab13bff85cc865d3/library/alloc/src/boxed.rs:1546:9
          std::sys::unix::thread::Thread::new::thread_start
                 at ./rustc/b849326744a8eec939e592f0ab13bff85cc865d3/library/std/src/sys/unix/thread.rs:71:17
      14: start_thread
      15: clone
```