### PR TITLE
Fix client substrate lost connection and dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,13 +741,13 @@ dependencies = [
 [[package]]
 name = "bridge-primitives"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#b3d1b1ef4adbca5a912cce02f137a5593ee2ce4d"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#db5f7808f496ce757326797a2b794a64669737db"
 dependencies = [
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bridge-runtime-common",
  "common-primitives 0.11.6",
- "darwinia-fee-market",
+ "darwinia-fee-market 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "pallet-bridge-dispatch",
  "sp-api",
@@ -765,7 +765,7 @@ dependencies = [
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bridge-runtime-common",
  "common-primitives 2.7.0",
- "darwinia-fee-market",
+ "darwinia-fee-market 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "pallet-bridge-dispatch",
  "sp-api",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "common-primitives"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#b3d1b1ef4adbca5a912cce02f137a5593ee2ce4d"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#db5f7808f496ce757326797a2b794a64669737db"
 dependencies = [
  "parity-scale-codec",
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1081,7 +1081,7 @@ version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "common-primitives 2.7.0",
- "darwinia-balances",
+ "darwinia-balances 2.7.0",
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1107,7 +1107,7 @@ dependencies = [
  "bridge-traits",
  "common-primitives 0.11.6",
  "crab-runtime",
- "dp-fee 2.6.10",
+ "dp-fee 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "headers-relay",
@@ -1133,9 +1133,9 @@ dependencies = [
  "bridge-primitives 0.11.6",
  "bridge-traits",
  "common-primitives 0.11.6",
- "darwinia-bridge-ethereum 2.6.10",
+ "darwinia-bridge-ethereum 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
  "darwinia-runtime",
- "dp-fee 2.6.10",
+ "dp-fee 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "headers-relay",
@@ -1424,7 +1424,7 @@ dependencies = [
 [[package]]
 name = "crab-runtime"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#b3d1b1ef4adbca5a912cce02f137a5593ee2ce4d"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#db5f7808f496ce757326797a2b794a64669737db"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -1433,27 +1433,27 @@ dependencies = [
  "bridge-primitives 0.11.6",
  "bridge-runtime-common",
  "common-primitives 0.11.6",
- "darwinia-balances",
- "darwinia-balances-rpc-runtime-api",
- "darwinia-claims",
- "darwinia-democracy",
- "darwinia-elections-phragmen",
- "darwinia-evm",
- "darwinia-evm-precompile-simple",
- "darwinia-evm-precompile-transfer",
- "darwinia-fee-market",
- "darwinia-fee-market-rpc-runtime-api",
- "darwinia-header-mmr",
- "darwinia-header-mmr-rpc-runtime-api",
+ "darwinia-balances 2.6.10",
+ "darwinia-balances-rpc-runtime-api 2.6.10",
+ "darwinia-claims 2.6.10",
+ "darwinia-democracy 2.6.10",
+ "darwinia-elections-phragmen 2.6.10",
+ "darwinia-evm 2.6.10",
+ "darwinia-evm-precompile-simple 2.6.10",
+ "darwinia-evm-precompile-transfer 2.6.10",
+ "darwinia-fee-market 2.6.10",
+ "darwinia-fee-market-rpc-runtime-api 2.6.10",
+ "darwinia-header-mmr 2.6.10",
+ "darwinia-header-mmr-rpc-runtime-api 2.6.6",
  "darwinia-runtime-common",
- "darwinia-staking",
- "darwinia-staking-rpc-runtime-api",
- "darwinia-support 2.7.0",
- "darwinia-vesting",
- "dp-evm",
- "dvm-ethereum",
- "dvm-rpc-runtime-api",
- "ethereum-primitives 2.7.0",
+ "darwinia-staking 2.6.10",
+ "darwinia-staking-rpc-runtime-api 2.6.10",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-vesting 2.6.10",
+ "dp-evm 2.6.10",
+ "dvm-ethereum 2.6.10",
+ "dvm-rpc-runtime-api 2.6.10",
+ "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
  "evm",
  "frame-executive",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1709,10 +1709,26 @@ dependencies = [
 
 [[package]]
 name = "darwinia-balances"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "darwinia-balances-rpc-runtime-api 2.6.10",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "log",
+ "max-encoded-len",
+ "parity-scale-codec",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-balances"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
- "darwinia-balances-rpc-runtime-api",
+ "darwinia-balances-rpc-runtime-api 2.7.0",
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1721,6 +1737,18 @@ dependencies = [
  "parity-scale-codec",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-balances-rpc-runtime-api"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "parity-scale-codec",
+ "serde 1.0.130",
+ "sp-api",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
 
 [[package]]
@@ -1758,10 +1786,34 @@ dependencies = [
  "array-bytes",
  "blake2-rfc",
  "ckb-merkle-mountain-range",
- "darwinia-relay-primitives 2.6.10",
- "darwinia-relayer-game 2.6.10",
- "darwinia-support 2.6.10",
- "ethereum-primitives 2.6.10",
+ "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
+ "darwinia-relayer-game 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
+ "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
+ "ethereum-types",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "parity-scale-codec",
+ "rlp 0.5.1",
+ "serde 1.0.130",
+ "serde_json",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-bridge-ethereum"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "array-bytes",
+ "blake2-rfc",
+ "ckb-merkle-mountain-range",
+ "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-relayer-game 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
  "ethereum-types",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1832,6 +1884,24 @@ dependencies = [
 
 [[package]]
 name = "darwinia-claims"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "array-bytes",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "log",
+ "parity-scale-codec",
+ "serde 1.0.130",
+ "serde_json",
+ "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-claims"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
@@ -1850,6 +1920,21 @@ dependencies = [
 
 [[package]]
 name = "darwinia-democracy"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "parity-scale-codec",
+ "serde 1.0.130",
+ "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-democracy"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
@@ -1859,6 +1944,23 @@ dependencies = [
  "parity-scale-codec",
  "serde 1.0.130",
  "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-elections-phragmen"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "log",
+ "parity-scale-codec",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-npos-elections",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
@@ -1882,13 +1984,41 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "array-bytes",
+ "darwinia-balances 2.6.10",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "dp-evm 2.6.10",
+ "evm",
+ "evm-gasometer",
+ "evm-runtime",
+ "frame-benchmarking",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "log",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "primitive-types",
+ "rlp 0.5.1",
+ "serde 1.0.130",
+ "sha3 0.9.1",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-evm"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
- "darwinia-balances",
+ "darwinia-balances 2.7.0",
  "darwinia-support 2.7.0",
- "dp-evm",
+ "dp-evm 2.7.0",
  "evm",
  "evm-gasometer",
  "evm-runtime",
@@ -1913,9 +2043,9 @@ name = "darwinia-evm-precompile-bridge-ethereum"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
- "darwinia-evm",
+ "darwinia-evm 2.7.0",
  "darwinia-evm-precompile-utils",
- "dp-evm",
+ "dp-evm 2.7.0",
  "evm",
  "from-ethereum-issuing",
  "parity-scale-codec",
@@ -1931,11 +2061,11 @@ source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bum
 dependencies = [
  "bp-message-dispatch",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "darwinia-evm",
+ "darwinia-evm 2.7.0",
  "darwinia-evm-precompile-utils",
  "darwinia-support 2.7.0",
  "dp-contract",
- "dp-evm",
+ "dp-evm 2.7.0",
  "dp-s2s",
  "evm",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1952,9 +2082,9 @@ name = "darwinia-evm-precompile-dispatch"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
- "darwinia-evm",
+ "darwinia-evm 2.7.0",
  "darwinia-support 2.7.0",
- "dp-evm",
+ "dp-evm 2.7.0",
  "evm",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
@@ -1964,10 +2094,22 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm-precompile-simple"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "dp-evm 2.6.10",
+ "evm",
+ "ripemd160",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-evm-precompile-simple"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
- "dp-evm",
+ "dp-evm 2.7.0",
  "evm",
  "ripemd160",
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1976,13 +2118,38 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm-precompile-transfer"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "array-bytes",
+ "darwinia-evm 2.6.10",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "dp-evm 2.6.10",
+ "ethabi 13.0.0",
+ "ethereum-types",
+ "evm",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "log",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "ripemd160",
+ "sha3 0.9.1",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-evm-precompile-transfer"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
- "darwinia-evm",
+ "darwinia-evm 2.7.0",
  "darwinia-support 2.7.0",
- "dp-evm",
+ "dp-evm 2.7.0",
  "ethabi 13.0.0",
  "ethereum-types",
  "evm",
@@ -2024,6 +2191,29 @@ dependencies = [
 
 [[package]]
 name = "darwinia-fee-market"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "bitvec",
+ "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "dp-fee 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "log",
+ "num-traits 0.2.14",
+ "pallet-bridge-messages",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-fee-market"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
@@ -2047,6 +2237,19 @@ dependencies = [
 
 [[package]]
 name = "darwinia-fee-market-rpc-runtime-api"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "parity-scale-codec",
+ "serde 1.0.130",
+ "sp-api",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-fee-market-rpc-runtime-api"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
@@ -2060,11 +2263,31 @@ dependencies = [
 
 [[package]]
 name = "darwinia-header-mmr"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "ckb-merkle-mountain-range",
+ "darwinia-header-mmr-rpc-runtime-api 2.6.6",
+ "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "log",
+ "parity-scale-codec",
+ "serde 1.0.130",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-header-mmr"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "ckb-merkle-mountain-range",
- "darwinia-header-mmr-rpc-runtime-api",
+ "darwinia-header-mmr-rpc-runtime-api 2.7.0",
  "darwinia-relay-primitives 2.7.0",
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2080,6 +2303,19 @@ dependencies = [
 
 [[package]]
 name = "darwinia-header-mmr-rpc-runtime-api"
+version = "2.6.6"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "parity-scale-codec",
+ "serde 1.0.130",
+ "sp-api",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-header-mmr-rpc-runtime-api"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
@@ -2087,6 +2323,21 @@ dependencies = [
  "parity-scale-codec",
  "serde 1.0.130",
  "sp-api",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-relay-authorities"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "log",
+ "parity-scale-codec",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
@@ -2119,6 +2370,17 @@ dependencies = [
 
 [[package]]
 name = "darwinia-relay-primitives"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "parity-scale-codec",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-relay-primitives"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
@@ -2133,8 +2395,23 @@ name = "darwinia-relayer-game"
 version = "2.6.10"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
 dependencies = [
- "darwinia-relay-primitives 2.6.10",
- "darwinia-support 2.6.10",
+ "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "log",
+ "parity-scale-codec",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-relayer-game"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "log",
@@ -2161,7 +2438,7 @@ dependencies = [
 [[package]]
 name = "darwinia-runtime"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#b3d1b1ef4adbca5a912cce02f137a5593ee2ce4d"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#db5f7808f496ce757326797a2b794a64669737db"
 dependencies = [
  "bp-message-dispatch",
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
@@ -2169,24 +2446,24 @@ dependencies = [
  "bridge-primitives 0.11.6",
  "bridge-runtime-common",
  "common-primitives 0.11.6",
- "darwinia-balances",
- "darwinia-balances-rpc-runtime-api",
- "darwinia-bridge-ethereum 2.7.0",
- "darwinia-democracy",
- "darwinia-elections-phragmen",
- "darwinia-fee-market",
- "darwinia-fee-market-rpc-runtime-api",
- "darwinia-header-mmr",
- "darwinia-header-mmr-rpc-runtime-api",
- "darwinia-relay-authorities",
- "darwinia-relay-primitives 2.7.0",
- "darwinia-relayer-game 2.7.0",
+ "darwinia-balances 2.6.10",
+ "darwinia-balances-rpc-runtime-api 2.6.10",
+ "darwinia-bridge-ethereum 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-democracy 2.6.10",
+ "darwinia-elections-phragmen 2.6.10",
+ "darwinia-fee-market 2.6.10",
+ "darwinia-fee-market-rpc-runtime-api 2.6.10",
+ "darwinia-header-mmr 2.6.10",
+ "darwinia-header-mmr-rpc-runtime-api 2.6.6",
+ "darwinia-relay-authorities 2.6.10",
+ "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-relayer-game 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
  "darwinia-runtime-common",
- "darwinia-staking",
- "darwinia-staking-rpc-runtime-api",
- "darwinia-support 2.7.0",
- "darwinia-vesting",
- "ethereum-primitives 2.7.0",
+ "darwinia-staking 2.6.10",
+ "darwinia-staking-rpc-runtime-api 2.6.10",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-vesting 2.6.10",
+ "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
  "frame-executive",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2242,19 +2519,19 @@ dependencies = [
  "sp-version 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "static_assertions",
  "substrate-wasm-builder",
- "to-ethereum-backing",
- "to-tron-backing",
+ "to-ethereum-backing 2.6.10",
+ "to-tron-backing 2.6.10",
 ]
 
 [[package]]
 name = "darwinia-runtime-common"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#b3d1b1ef4adbca5a912cce02f137a5593ee2ce4d"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#db5f7808f496ce757326797a2b794a64669737db"
 dependencies = [
  "common-primitives 0.11.6",
- "darwinia-balances",
- "darwinia-staking",
- "darwinia-support 2.7.0",
+ "darwinia-balances 2.6.10",
+ "darwinia-staking 2.6.10",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "max-encoded-len",
@@ -2269,10 +2546,34 @@ dependencies = [
 
 [[package]]
 name = "darwinia-staking"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "darwinia-staking-rpc-runtime-api 2.6.10",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "frame-election-provider-support",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "pallet-authorship 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "pallet-session",
+ "parity-scale-codec",
+ "serde 1.0.130",
+ "sp-arithmetic 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-staking 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "static_assertions",
+ "substrate-fixed",
+]
+
+[[package]]
+name = "darwinia-staking"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
- "darwinia-staking-rpc-runtime-api",
+ "darwinia-staking-rpc-runtime-api 2.7.0",
  "darwinia-support 2.7.0",
  "frame-election-provider-support",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2289,6 +2590,18 @@ dependencies = [
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "static_assertions",
  "substrate-fixed",
+]
+
+[[package]]
+name = "darwinia-staking-rpc-runtime-api"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "parity-scale-codec",
+ "serde 1.0.130",
+ "sp-api",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
 
 [[package]]
@@ -2311,7 +2624,29 @@ dependencies = [
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
  "ethereum",
- "ethereum-primitives 2.6.10",
+ "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "impl-trait-for-tuples",
+ "max-encoded-len",
+ "num-traits 0.2.14",
+ "parity-scale-codec",
+ "sha3 0.9.1",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-support"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "ethereum",
+ "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "impl-trait-for-tuples",
@@ -2343,6 +2678,19 @@ dependencies = [
  "sha3 0.9.1",
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-vesting"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "parity-scale-codec",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
@@ -2478,6 +2826,20 @@ dependencies = [
 
 [[package]]
 name = "dp-consensus"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "ethereum",
+ "parity-scale-codec",
+ "rlp 0.5.1",
+ "sha3 0.9.1",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "dp-consensus"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
@@ -2505,6 +2867,19 @@ dependencies = [
 
 [[package]]
 name = "dp-evm"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "evm",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "serde 1.0.130",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "dp-evm"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
@@ -2522,6 +2897,18 @@ version = "2.6.10"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
 dependencies = [
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "parity-scale-codec",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "dp-fee"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2558,6 +2945,11 @@ dependencies = [
 
 [[package]]
 name = "dp-storage"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+
+[[package]]
+name = "dp-storage"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 
@@ -2569,15 +2961,44 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "dvm-ethereum"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "darwinia-evm 2.6.10",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "dp-consensus 2.6.10",
+ "dp-evm 2.6.10",
+ "dp-storage 2.6.10",
+ "dvm-rpc-runtime-api 2.6.10",
+ "ethereum",
+ "ethereum-types",
+ "evm",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "libsecp256k1 0.5.0",
+ "log",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "rlp 0.5.1",
+ "serde 1.0.130",
+ "sha3 0.9.1",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "dvm-ethereum"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
- "darwinia-evm",
+ "darwinia-evm 2.7.0",
  "darwinia-support 2.7.0",
- "dp-consensus",
- "dp-evm",
- "dp-storage",
- "dvm-rpc-runtime-api",
+ "dp-consensus 2.7.0",
+ "dp-evm 2.7.0",
+ "dp-storage 2.7.0",
+ "dvm-rpc-runtime-api 2.7.0",
  "ethereum",
  "ethereum-types",
  "evm",
@@ -2598,12 +3019,30 @@ dependencies = [
 
 [[package]]
 name = "dvm-rpc-runtime-api"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "darwinia-evm 2.6.10",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "dp-evm 2.6.10",
+ "ethereum",
+ "ethereum-types",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "dvm-rpc-runtime-api"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
- "darwinia-evm",
+ "darwinia-evm 2.7.0",
  "darwinia-support 2.7.0",
- "dp-evm",
+ "dp-evm 2.7.0",
  "ethereum",
  "ethereum-types",
  "parity-scale-codec",
@@ -2836,7 +3275,26 @@ dependencies = [
  "ethbloom",
  "ethereum-types",
  "keccak-hash",
- "merkle-patricia-trie 2.6.10",
+ "merkle-patricia-trie 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
+ "parity-scale-codec",
+ "rlp 0.5.1",
+ "rlp-derive",
+ "serde 1.0.130",
+ "sp-debug-derive 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subhasher",
+]
+
+[[package]]
+name = "ethereum-primitives"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "array-bytes",
+ "ethash",
+ "ethbloom",
+ "ethereum-types",
+ "keccak-hash",
+ "merkle-patricia-trie 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
  "parity-scale-codec",
  "rlp 0.5.1",
  "rlp-derive",
@@ -3351,12 +3809,12 @@ source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bum
 dependencies = [
  "array-bytes",
  "darwinia-bridge-ethereum 2.7.0",
- "darwinia-evm",
+ "darwinia-evm 2.7.0",
  "darwinia-relay-primitives 2.7.0",
  "darwinia-support 2.7.0",
  "dp-contract",
- "dp-evm",
- "dvm-ethereum",
+ "dp-evm 2.7.0",
+ "dvm-ethereum 2.7.0",
  "ethereum-primitives 2.7.0",
  "frame-benchmarking",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -3377,13 +3835,13 @@ dependencies = [
  "bp-message-dispatch",
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "darwinia-evm",
+ "darwinia-evm 2.7.0",
  "darwinia-support 2.7.0",
  "dp-asset",
  "dp-contract",
- "dp-evm",
+ "dp-evm 2.7.0",
  "dp-s2s",
- "dvm-ethereum",
+ "dvm-ethereum 2.7.0",
  "ethereum-primitives 2.7.0",
  "ethereum-types",
  "frame-benchmarking",
@@ -5214,6 +5672,17 @@ dependencies = [
 
 [[package]]
 name = "merkle-patricia-trie"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "hashbrown 0.9.1",
+ "keccak-hash",
+ "rlp 0.5.1",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "merkle-patricia-trie"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
@@ -6187,37 +6656,37 @@ dependencies = [
  "bridge-runtime-common",
  "common-primitives 2.7.0",
  "common-runtime",
- "darwinia-balances",
- "darwinia-balances-rpc-runtime-api",
+ "darwinia-balances 2.7.0",
+ "darwinia-balances-rpc-runtime-api 2.7.0",
  "darwinia-bridge-bsc",
  "darwinia-bridge-ethereum 2.7.0",
- "darwinia-claims",
- "darwinia-democracy",
- "darwinia-elections-phragmen",
- "darwinia-evm",
+ "darwinia-claims 2.7.0",
+ "darwinia-democracy 2.7.0",
+ "darwinia-elections-phragmen 2.7.0",
+ "darwinia-evm 2.7.0",
  "darwinia-evm-precompile-bridge-ethereum",
  "darwinia-evm-precompile-bridge-s2s",
  "darwinia-evm-precompile-dispatch",
- "darwinia-evm-precompile-simple",
- "darwinia-evm-precompile-transfer",
- "darwinia-fee-market",
- "darwinia-fee-market-rpc-runtime-api",
- "darwinia-header-mmr",
- "darwinia-header-mmr-rpc-runtime-api",
- "darwinia-relay-authorities",
+ "darwinia-evm-precompile-simple 2.7.0",
+ "darwinia-evm-precompile-transfer 2.7.0",
+ "darwinia-fee-market 2.7.0",
+ "darwinia-fee-market-rpc-runtime-api 2.7.0",
+ "darwinia-header-mmr 2.7.0",
+ "darwinia-header-mmr-rpc-runtime-api 2.7.0",
+ "darwinia-relay-authorities 2.7.0",
  "darwinia-relay-primitives 2.7.0",
  "darwinia-relayer-game 2.7.0",
- "darwinia-staking",
- "darwinia-staking-rpc-runtime-api",
+ "darwinia-staking 2.7.0",
+ "darwinia-staking-rpc-runtime-api 2.7.0",
  "darwinia-support 2.7.0",
- "darwinia-vesting",
+ "darwinia-vesting 2.7.0",
  "dp-asset",
  "dp-contract",
- "dp-evm",
+ "dp-evm 2.7.0",
  "dp-fee 2.7.0",
  "dp-s2s",
- "dvm-ethereum",
- "dvm-rpc-runtime-api",
+ "dvm-ethereum 2.7.0",
+ "dvm-rpc-runtime-api 2.7.0",
  "ethereum-primitives 2.7.0",
  "evm",
  "frame-benchmarking",
@@ -6281,8 +6750,8 @@ dependencies = [
  "sp-version 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "static_assertions",
  "substrate-wasm-builder",
- "to-ethereum-backing",
- "to-tron-backing",
+ "to-ethereum-backing 2.7.0",
+ "to-tron-backing 2.7.0",
 ]
 
 [[package]]
@@ -6299,12 +6768,12 @@ dependencies = [
  "bridge-runtime-common",
  "common-primitives 2.7.0",
  "common-runtime",
- "darwinia-balances",
- "darwinia-balances-rpc-runtime-api",
- "darwinia-evm",
- "darwinia-fee-market",
- "darwinia-fee-market-rpc-runtime-api",
- "darwinia-staking",
+ "darwinia-balances 2.7.0",
+ "darwinia-balances-rpc-runtime-api 2.7.0",
+ "darwinia-evm 2.7.0",
+ "darwinia-fee-market 2.7.0",
+ "darwinia-fee-market-rpc-runtime-api 2.7.0",
+ "darwinia-staking 2.7.0",
  "darwinia-support 2.7.0",
  "dp-asset",
  "dp-fee 2.7.0",
@@ -10254,6 +10723,27 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "to-ethereum-backing"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "array-bytes",
+ "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "ethabi 13.0.0",
+ "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "log",
+ "parity-scale-codec",
+ "serde 1.0.130",
+ "serde_json",
+ "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "to-ethereum-backing"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
@@ -10297,6 +10787,18 @@ dependencies = [
  "serde_json",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "to-tron-backing"
+version = "2.6.10"
+source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+dependencies = [
+ "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "parity-scale-codec",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,21 +622,6 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3#e26d59105acb795161881e49eb14992b8b0c22fa"
-dependencies = [
- "finality-grandpa",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "parity-scale-codec",
- "serde 1.0.130",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-finality-grandpa",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "bp-header-chain"
-version = "0.1.0"
 source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4#495a773403e5827bbf9d7b20d97333f673628db9"
 dependencies = [
  "finality-grandpa",
@@ -646,17 +631,6 @@ dependencies = [
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-finality-grandpa",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "bp-message-dispatch"
-version = "0.1.0"
-source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3#e26d59105acb795161881e49eb14992b8b0c22fa"
-dependencies = [
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "parity-scale-codec",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
 
@@ -738,24 +712,9 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3#e26d59105acb795161881e49eb14992b8b0c22fa"
-dependencies = [
- "bp-header-chain 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "ed25519-dalek",
- "finality-grandpa",
- "parity-scale-codec",
- "sp-application-crypto 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-finality-grandpa",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "bp-test-utils"
-version = "0.1.0"
 source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4#495a773403e5827bbf9d7b20d97333f673628db9"
 dependencies = [
- "bp-header-chain 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-header-chain",
  "ed25519-dalek",
  "finality-grandpa",
  "parity-scale-codec",
@@ -782,15 +741,15 @@ dependencies = [
 [[package]]
 name = "bridge-primitives"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?tag=v0.11.6#c5143a275f834f61c5a9c3fccb462943b194395d"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#ec6d5faafbd5c57b0316163dcaecb52dae620e3c"
 dependencies = [
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bridge-runtime-common 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
+ "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bridge-runtime-common",
  "common-primitives 0.11.6",
- "darwinia-fee-market 2.6.10",
+ "darwinia-fee-market",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "pallet-bridge-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
+ "pallet-bridge-dispatch",
  "sp-api",
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -804,11 +763,11 @@ source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bum
 dependencies = [
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-runtime-common 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bridge-runtime-common",
  "common-primitives 2.7.0",
- "darwinia-fee-market 2.7.0",
+ "darwinia-fee-market",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "pallet-bridge-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "pallet-bridge-dispatch",
  "sp-api",
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -818,38 +777,16 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3#e26d59105acb795161881e49eb14992b8b0c22fa"
-dependencies = [
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "hash-db",
- "pallet-bridge-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "pallet-bridge-grandpa 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "pallet-bridge-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "pallet-transaction-payment",
- "parity-scale-codec",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-state-machine 0.9.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-trie 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "bridge-runtime-common"
-version = "0.1.0"
 source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4#495a773403e5827bbf9d7b20d97333f673628db9"
 dependencies = [
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-message-dispatch",
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "hash-db",
- "pallet-bridge-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "pallet-bridge-grandpa 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "pallet-bridge-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "pallet-bridge-dispatch",
+ "pallet-bridge-grandpa",
+ "pallet-bridge-messages",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1122,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "common-primitives"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?tag=v0.11.6#c5143a275f834f61c5a9c3fccb462943b194395d"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#ec6d5faafbd5c57b0316163dcaecb52dae620e3c"
 dependencies = [
  "parity-scale-codec",
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1144,7 +1081,7 @@ version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
  "common-primitives 2.7.0",
- "darwinia-balances 2.7.0",
+ "darwinia-balances",
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1283,7 +1220,6 @@ dependencies = [
  "dp-fee 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "futures 0.3.17",
  "futures-test",
  "headers-relay",
  "log",
@@ -1488,36 +1424,36 @@ dependencies = [
 [[package]]
 name = "crab-runtime"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?tag=v0.11.6#c5143a275f834f61c5a9c3fccb462943b194395d"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#ec6d5faafbd5c57b0316163dcaecb52dae620e3c"
 dependencies = [
  "array-bytes",
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
+ "bp-message-dispatch",
+ "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bridge-primitives 0.11.6",
- "bridge-runtime-common 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
+ "bridge-runtime-common",
  "common-primitives 0.11.6",
- "darwinia-balances 2.6.10",
- "darwinia-balances-rpc-runtime-api 2.6.10",
- "darwinia-claims 2.6.10",
- "darwinia-democracy 2.6.10",
- "darwinia-elections-phragmen 2.6.10",
- "darwinia-evm 2.6.10",
- "darwinia-evm-precompile-simple 2.6.10",
- "darwinia-evm-precompile-transfer 2.6.10",
- "darwinia-fee-market 2.6.10",
- "darwinia-fee-market-rpc-runtime-api 2.6.10",
- "darwinia-header-mmr 2.6.10",
- "darwinia-header-mmr-rpc-runtime-api 2.6.6",
- "darwinia-runtime-common",
- "darwinia-staking 2.6.10",
- "darwinia-staking-rpc-runtime-api 2.6.10",
- "darwinia-support 2.6.10",
- "darwinia-vesting 2.6.10",
- "dp-evm 2.6.10",
- "dvm-ethereum 2.6.10",
- "dvm-rpc-runtime-api 2.6.10",
- "ethereum-primitives 2.6.10",
+ "darwinia-balances",
+ "darwinia-balances-rpc-runtime-api",
+ "darwinia-claims",
+ "darwinia-common-runtime",
+ "darwinia-democracy",
+ "darwinia-elections-phragmen",
+ "darwinia-evm",
+ "darwinia-evm-precompile-simple",
+ "darwinia-evm-precompile-transfer",
+ "darwinia-fee-market",
+ "darwinia-fee-market-rpc-runtime-api",
+ "darwinia-header-mmr",
+ "darwinia-header-mmr-rpc-runtime-api",
+ "darwinia-staking",
+ "darwinia-staking-rpc-runtime-api",
+ "darwinia-support 2.7.0",
+ "darwinia-vesting",
+ "dp-evm",
+ "dvm-ethereum",
+ "dvm-rpc-runtime-api",
+ "ethereum-primitives 2.7.0",
  "evm",
  "frame-executive",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1530,9 +1466,9 @@ dependencies = [
  "pallet-authorship 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "pallet-babe",
  "pallet-bounties",
- "pallet-bridge-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "pallet-bridge-grandpa 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "pallet-bridge-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
+ "pallet-bridge-dispatch",
+ "pallet-bridge-grandpa",
+ "pallet-bridge-messages",
  "pallet-collective",
  "pallet-election-provider-multi-phase",
  "pallet-grandpa",
@@ -1773,26 +1709,10 @@ dependencies = [
 
 [[package]]
 name = "darwinia-balances"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "darwinia-balances-rpc-runtime-api 2.6.10",
- "darwinia-support 2.6.10",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "log",
- "max-encoded-len",
- "parity-scale-codec",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-balances"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
- "darwinia-balances-rpc-runtime-api 2.7.0",
+ "darwinia-balances-rpc-runtime-api",
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1801,18 +1721,6 @@ dependencies = [
  "parity-scale-codec",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-balances-rpc-runtime-api"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "darwinia-support 2.6.10",
- "parity-scale-codec",
- "serde 1.0.130",
- "sp-api",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
 
 [[package]]
@@ -1924,24 +1832,6 @@ dependencies = [
 
 [[package]]
 name = "darwinia-claims"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "array-bytes",
- "darwinia-support 2.6.10",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "log",
- "parity-scale-codec",
- "serde 1.0.130",
- "serde_json",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-claims"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
@@ -1959,18 +1849,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "darwinia-democracy"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
+name = "darwinia-common-runtime"
+version = "0.11.6"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#ec6d5faafbd5c57b0316163dcaecb52dae620e3c"
 dependencies = [
- "darwinia-support 2.6.10",
+ "common-primitives 0.11.6",
+ "darwinia-balances",
+ "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "max-encoded-len",
+ "pallet-authorship 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "pallet-transaction-payment",
+ "pallet-treasury",
  "parity-scale-codec",
- "serde 1.0.130",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1984,23 +1879,6 @@ dependencies = [
  "parity-scale-codec",
  "serde 1.0.130",
  "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-elections-phragmen"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "darwinia-support 2.6.10",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "log",
- "parity-scale-codec",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-npos-elections",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
@@ -2024,41 +1902,13 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "array-bytes",
- "darwinia-balances 2.6.10",
- "darwinia-support 2.6.10",
- "dp-evm 2.6.10",
- "evm",
- "evm-gasometer",
- "evm-runtime",
- "frame-benchmarking",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "log",
- "pallet-timestamp",
- "parity-scale-codec",
- "primitive-types",
- "rlp 0.5.1",
- "serde 1.0.130",
- "sha3 0.9.1",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-evm"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
  "array-bytes",
- "darwinia-balances 2.7.0",
+ "darwinia-balances",
  "darwinia-support 2.7.0",
- "dp-evm 2.7.0",
+ "dp-evm",
  "evm",
  "evm-gasometer",
  "evm-runtime",
@@ -2083,9 +1933,9 @@ name = "darwinia-evm-precompile-bridge-ethereum"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
- "darwinia-evm 2.7.0",
+ "darwinia-evm",
  "darwinia-evm-precompile-utils",
- "dp-evm 2.7.0",
+ "dp-evm",
  "evm",
  "from-ethereum-issuing",
  "parity-scale-codec",
@@ -2099,13 +1949,13 @@ name = "darwinia-evm-precompile-bridge-s2s"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-message-dispatch",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "darwinia-evm 2.7.0",
+ "darwinia-evm",
  "darwinia-evm-precompile-utils",
  "darwinia-support 2.7.0",
  "dp-contract",
- "dp-evm 2.7.0",
+ "dp-evm",
  "dp-s2s",
  "evm",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2122,9 +1972,9 @@ name = "darwinia-evm-precompile-dispatch"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
- "darwinia-evm 2.7.0",
+ "darwinia-evm",
  "darwinia-support 2.7.0",
- "dp-evm 2.7.0",
+ "dp-evm",
  "evm",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
@@ -2134,22 +1984,10 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm-precompile-simple"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "dp-evm 2.6.10",
- "evm",
- "ripemd160",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-evm-precompile-simple"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
- "dp-evm 2.7.0",
+ "dp-evm",
  "evm",
  "ripemd160",
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2158,38 +1996,13 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm-precompile-transfer"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "array-bytes",
- "darwinia-evm 2.6.10",
- "darwinia-support 2.6.10",
- "dp-evm 2.6.10",
- "ethabi 13.0.0",
- "ethereum-types",
- "evm",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "log",
- "pallet-timestamp",
- "parity-scale-codec",
- "ripemd160",
- "sha3 0.9.1",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-evm-precompile-transfer"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
  "array-bytes",
- "darwinia-evm 2.7.0",
+ "darwinia-evm",
  "darwinia-support 2.7.0",
- "dp-evm 2.7.0",
+ "dp-evm",
  "ethabi 13.0.0",
  "ethereum-types",
  "evm",
@@ -2231,29 +2044,6 @@ dependencies = [
 
 [[package]]
 name = "darwinia-fee-market"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "bitvec",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "darwinia-support 2.6.10",
- "dp-fee 2.6.10",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "log",
- "num-traits 0.2.14",
- "pallet-bridge-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "pallet-timestamp",
- "parity-scale-codec",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-fee-market"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
@@ -2266,24 +2056,11 @@ dependencies = [
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "log",
  "num-traits 0.2.14",
- "pallet-bridge-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "pallet-bridge-messages",
  "pallet-timestamp",
  "parity-scale-codec",
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-fee-market-rpc-runtime-api"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "parity-scale-codec",
- "serde 1.0.130",
- "sp-api",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
@@ -2303,31 +2080,11 @@ dependencies = [
 
 [[package]]
 name = "darwinia-header-mmr"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "ckb-merkle-mountain-range",
- "darwinia-header-mmr-rpc-runtime-api 2.6.6",
- "darwinia-relay-primitives 2.6.10",
- "darwinia-support 2.6.10",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "log",
- "parity-scale-codec",
- "serde 1.0.130",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-header-mmr"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
  "ckb-merkle-mountain-range",
- "darwinia-header-mmr-rpc-runtime-api 2.7.0",
+ "darwinia-header-mmr-rpc-runtime-api",
  "darwinia-relay-primitives 2.7.0",
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2343,19 +2100,6 @@ dependencies = [
 
 [[package]]
 name = "darwinia-header-mmr-rpc-runtime-api"
-version = "2.6.6"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "darwinia-support 2.6.10",
- "parity-scale-codec",
- "serde 1.0.130",
- "sp-api",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-header-mmr-rpc-runtime-api"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
@@ -2363,21 +2107,6 @@ dependencies = [
  "parity-scale-codec",
  "serde 1.0.130",
  "sp-api",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-relay-authorities"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "darwinia-relay-primitives 2.6.10",
- "darwinia-support 2.6.10",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "log",
- "parity-scale-codec",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
@@ -2452,32 +2181,32 @@ dependencies = [
 [[package]]
 name = "darwinia-runtime"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?tag=v0.11.6#c5143a275f834f61c5a9c3fccb462943b194395d"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#ec6d5faafbd5c57b0316163dcaecb52dae620e3c"
 dependencies = [
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
+ "bp-message-dispatch",
+ "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bridge-primitives 0.11.6",
- "bridge-runtime-common 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
+ "bridge-runtime-common",
  "common-primitives 0.11.6",
- "darwinia-balances 2.6.10",
- "darwinia-balances-rpc-runtime-api 2.6.10",
- "darwinia-bridge-ethereum 2.6.10",
- "darwinia-democracy 2.6.10",
- "darwinia-elections-phragmen 2.6.10",
- "darwinia-fee-market 2.6.10",
- "darwinia-fee-market-rpc-runtime-api 2.6.10",
- "darwinia-header-mmr 2.6.10",
- "darwinia-header-mmr-rpc-runtime-api 2.6.6",
- "darwinia-relay-authorities 2.6.10",
- "darwinia-relay-primitives 2.6.10",
- "darwinia-relayer-game 2.6.10",
- "darwinia-runtime-common",
- "darwinia-staking 2.6.10",
- "darwinia-staking-rpc-runtime-api 2.6.10",
- "darwinia-support 2.6.10",
- "darwinia-vesting 2.6.10",
- "ethereum-primitives 2.6.10",
+ "darwinia-balances",
+ "darwinia-balances-rpc-runtime-api",
+ "darwinia-bridge-ethereum 2.7.0",
+ "darwinia-common-runtime",
+ "darwinia-democracy",
+ "darwinia-elections-phragmen",
+ "darwinia-fee-market",
+ "darwinia-fee-market-rpc-runtime-api",
+ "darwinia-header-mmr",
+ "darwinia-header-mmr-rpc-runtime-api",
+ "darwinia-relay-authorities",
+ "darwinia-relay-primitives 2.7.0",
+ "darwinia-relayer-game 2.7.0",
+ "darwinia-staking",
+ "darwinia-staking-rpc-runtime-api",
+ "darwinia-support 2.7.0",
+ "darwinia-vesting",
+ "ethereum-primitives 2.7.0",
  "frame-executive",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2489,9 +2218,9 @@ dependencies = [
  "pallet-authorship 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "pallet-babe",
  "pallet-bounties",
- "pallet-bridge-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "pallet-bridge-grandpa 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "pallet-bridge-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
+ "pallet-bridge-dispatch",
+ "pallet-bridge-grandpa",
+ "pallet-bridge-messages",
  "pallet-collective",
  "pallet-election-provider-multi-phase",
  "pallet-grandpa",
@@ -2533,53 +2262,8 @@ dependencies = [
  "sp-version 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "static_assertions",
  "substrate-wasm-builder",
- "to-ethereum-backing 2.6.10",
- "to-tron-backing 2.6.10",
-]
-
-[[package]]
-name = "darwinia-runtime-common"
-version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?tag=v0.11.6#c5143a275f834f61c5a9c3fccb462943b194395d"
-dependencies = [
- "common-primitives 0.11.6",
- "darwinia-balances 2.6.10",
- "darwinia-staking 2.6.10",
- "darwinia-support 2.6.10",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "max-encoded-len",
- "pallet-authorship 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "pallet-transaction-payment",
- "pallet-treasury",
- "parity-scale-codec",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "static_assertions",
-]
-
-[[package]]
-name = "darwinia-staking"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "darwinia-staking-rpc-runtime-api 2.6.10",
- "darwinia-support 2.6.10",
- "frame-election-provider-support",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "pallet-authorship 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "pallet-session",
- "parity-scale-codec",
- "serde 1.0.130",
- "sp-arithmetic 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-staking 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "static_assertions",
- "substrate-fixed",
+ "to-ethereum-backing",
+ "to-tron-backing",
 ]
 
 [[package]]
@@ -2587,7 +2271,7 @@ name = "darwinia-staking"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
- "darwinia-staking-rpc-runtime-api 2.7.0",
+ "darwinia-staking-rpc-runtime-api",
  "darwinia-support 2.7.0",
  "frame-election-provider-support",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2604,18 +2288,6 @@ dependencies = [
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "static_assertions",
  "substrate-fixed",
-]
-
-[[package]]
-name = "darwinia-staking-rpc-runtime-api"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "darwinia-support 2.6.10",
- "parity-scale-codec",
- "serde 1.0.130",
- "sp-api",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
 
 [[package]]
@@ -2670,19 +2342,6 @@ dependencies = [
  "sha3 0.9.1",
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-vesting"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "darwinia-support 2.6.10",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "parity-scale-codec",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
@@ -2818,20 +2477,6 @@ dependencies = [
 
 [[package]]
 name = "dp-consensus"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "ethereum",
- "parity-scale-codec",
- "rlp 0.5.1",
- "sha3 0.9.1",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "dp-consensus"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
@@ -2854,19 +2499,6 @@ dependencies = [
  "ethabi 13.0.0",
  "ethereum-primitives 2.7.0",
  "ethereum-types",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "dp-evm"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "evm",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "serde 1.0.130",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
 
@@ -2913,7 +2545,7 @@ version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
  "array-bytes",
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-message-dispatch",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "dp-asset",
  "dp-contract",
@@ -2922,11 +2554,6 @@ dependencies = [
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
-
-[[package]]
-name = "dp-storage"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
 
 [[package]]
 name = "dp-storage"
@@ -2941,44 +2568,15 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "dvm-ethereum"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "darwinia-evm 2.6.10",
- "darwinia-support 2.6.10",
- "dp-consensus 2.6.10",
- "dp-evm 2.6.10",
- "dp-storage 2.6.10",
- "dvm-rpc-runtime-api 2.6.10",
- "ethereum",
- "ethereum-types",
- "evm",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "libsecp256k1 0.5.0",
- "log",
- "pallet-timestamp",
- "parity-scale-codec",
- "rlp 0.5.1",
- "serde 1.0.130",
- "sha3 0.9.1",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "dvm-ethereum"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
- "darwinia-evm 2.7.0",
+ "darwinia-evm",
  "darwinia-support 2.7.0",
- "dp-consensus 2.7.0",
- "dp-evm 2.7.0",
- "dp-storage 2.7.0",
- "dvm-rpc-runtime-api 2.7.0",
+ "dp-consensus",
+ "dp-evm",
+ "dp-storage",
+ "dvm-rpc-runtime-api",
  "ethereum",
  "ethereum-types",
  "evm",
@@ -2999,30 +2597,12 @@ dependencies = [
 
 [[package]]
 name = "dvm-rpc-runtime-api"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "darwinia-evm 2.6.10",
- "darwinia-support 2.6.10",
- "dp-evm 2.6.10",
- "ethereum",
- "ethereum-types",
- "parity-scale-codec",
- "sp-api",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "dvm-rpc-runtime-api"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
- "darwinia-evm 2.7.0",
+ "darwinia-evm",
  "darwinia-support 2.7.0",
- "dp-evm 2.7.0",
+ "dp-evm",
  "ethereum",
  "ethereum-types",
  "parity-scale-codec",
@@ -3421,7 +3001,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "backoff",
- "bp-header-chain 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-header-chain",
  "futures 0.3.17",
  "headers-relay",
  "log",
@@ -3770,12 +3350,12 @@ source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bum
 dependencies = [
  "array-bytes",
  "darwinia-bridge-ethereum 2.7.0",
- "darwinia-evm 2.7.0",
+ "darwinia-evm",
  "darwinia-relay-primitives 2.7.0",
  "darwinia-support 2.7.0",
  "dp-contract",
- "dp-evm 2.7.0",
- "dvm-ethereum 2.7.0",
+ "dp-evm",
+ "dvm-ethereum",
  "ethereum-primitives 2.7.0",
  "frame-benchmarking",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -3793,16 +3373,16 @@ version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
  "array-bytes",
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-message-dispatch",
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "darwinia-evm 2.7.0",
+ "darwinia-evm",
  "darwinia-support 2.7.0",
  "dp-asset",
  "dp-contract",
- "dp-evm 2.7.0",
+ "dp-evm",
  "dp-s2s",
- "dvm-ethereum 2.7.0",
+ "dvm-ethereum",
  "ethereum-primitives 2.7.0",
  "ethereum-types",
  "frame-benchmarking",
@@ -6142,25 +5722,9 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3#e26d59105acb795161881e49eb14992b8b0c22fa"
-dependencies = [
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "log",
- "parity-scale-codec",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "pallet-bridge-dispatch"
-version = "0.1.0"
 source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4#495a773403e5827bbf9d7b20d97333f673628db9"
 dependencies = [
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-message-dispatch",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -6174,32 +5738,11 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3#e26d59105acb795161881e49eb14992b8b0c22fa"
-dependencies = [
- "bp-header-chain 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-test-utils 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "finality-grandpa",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "log",
- "num-traits 0.2.14",
- "parity-scale-codec",
- "serde 1.0.130",
- "sp-finality-grandpa",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-trie 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "pallet-bridge-grandpa"
-version = "0.1.0"
 source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4#495a773403e5827bbf9d7b20d97333f673628db9"
 dependencies = [
- "bp-header-chain 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-header-chain",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-test-utils 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-test-utils",
  "finality-grandpa",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -6216,30 +5759,10 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3#e26d59105acb795161881e49eb14992b8b0c22fa"
-dependencies = [
- "bitvec",
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "log",
- "num-traits 0.2.14",
- "parity-scale-codec",
- "serde 1.0.130",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "pallet-bridge-messages"
-version = "0.1.0"
 source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4#495a773403e5827bbf9d7b20d97333f673628db9"
 dependencies = [
  "bitvec",
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-message-dispatch",
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -6656,44 +6179,44 @@ version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
  "array-bytes",
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-message-dispatch",
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bridge-primitives 2.7.0",
- "bridge-runtime-common 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bridge-runtime-common",
  "common-primitives 2.7.0",
  "common-runtime",
- "darwinia-balances 2.7.0",
- "darwinia-balances-rpc-runtime-api 2.7.0",
+ "darwinia-balances",
+ "darwinia-balances-rpc-runtime-api",
  "darwinia-bridge-bsc",
  "darwinia-bridge-ethereum 2.7.0",
- "darwinia-claims 2.7.0",
- "darwinia-democracy 2.7.0",
- "darwinia-elections-phragmen 2.7.0",
- "darwinia-evm 2.7.0",
+ "darwinia-claims",
+ "darwinia-democracy",
+ "darwinia-elections-phragmen",
+ "darwinia-evm",
  "darwinia-evm-precompile-bridge-ethereum",
  "darwinia-evm-precompile-bridge-s2s",
  "darwinia-evm-precompile-dispatch",
- "darwinia-evm-precompile-simple 2.7.0",
- "darwinia-evm-precompile-transfer 2.7.0",
- "darwinia-fee-market 2.7.0",
- "darwinia-fee-market-rpc-runtime-api 2.7.0",
- "darwinia-header-mmr 2.7.0",
- "darwinia-header-mmr-rpc-runtime-api 2.7.0",
- "darwinia-relay-authorities 2.7.0",
+ "darwinia-evm-precompile-simple",
+ "darwinia-evm-precompile-transfer",
+ "darwinia-fee-market",
+ "darwinia-fee-market-rpc-runtime-api",
+ "darwinia-header-mmr",
+ "darwinia-header-mmr-rpc-runtime-api",
+ "darwinia-relay-authorities",
  "darwinia-relay-primitives 2.7.0",
  "darwinia-relayer-game 2.7.0",
- "darwinia-staking 2.7.0",
- "darwinia-staking-rpc-runtime-api 2.7.0",
+ "darwinia-staking",
+ "darwinia-staking-rpc-runtime-api",
  "darwinia-support 2.7.0",
- "darwinia-vesting 2.7.0",
+ "darwinia-vesting",
  "dp-asset",
  "dp-contract",
- "dp-evm 2.7.0",
+ "dp-evm",
  "dp-fee 2.7.0",
  "dp-s2s",
- "dvm-ethereum 2.7.0",
- "dvm-rpc-runtime-api 2.7.0",
+ "dvm-ethereum",
+ "dvm-rpc-runtime-api",
  "ethereum-primitives 2.7.0",
  "evm",
  "frame-benchmarking",
@@ -6712,9 +6235,9 @@ dependencies = [
  "pallet-authorship 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "pallet-babe",
  "pallet-bounties",
- "pallet-bridge-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "pallet-bridge-grandpa 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "pallet-bridge-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "pallet-bridge-dispatch",
+ "pallet-bridge-grandpa",
+ "pallet-bridge-messages",
  "pallet-collective",
  "pallet-election-provider-multi-phase",
  "pallet-grandpa",
@@ -6757,8 +6280,8 @@ dependencies = [
  "sp-version 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "static_assertions",
  "substrate-wasm-builder",
- "to-ethereum-backing 2.7.0",
- "to-tron-backing 2.7.0",
+ "to-ethereum-backing",
+ "to-tron-backing",
 ]
 
 [[package]]
@@ -6767,20 +6290,20 @@ version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
  "array-bytes",
- "bp-header-chain 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-header-chain",
+ "bp-message-dispatch",
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bridge-primitives 2.7.0",
- "bridge-runtime-common 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bridge-runtime-common",
  "common-primitives 2.7.0",
  "common-runtime",
- "darwinia-balances 2.7.0",
- "darwinia-balances-rpc-runtime-api 2.7.0",
- "darwinia-evm 2.7.0",
- "darwinia-fee-market 2.7.0",
- "darwinia-fee-market-rpc-runtime-api 2.7.0",
- "darwinia-staking 2.7.0",
+ "darwinia-balances",
+ "darwinia-balances-rpc-runtime-api",
+ "darwinia-evm",
+ "darwinia-fee-market",
+ "darwinia-fee-market-rpc-runtime-api",
+ "darwinia-staking",
  "darwinia-support 2.7.0",
  "dp-asset",
  "dp-fee 2.7.0",
@@ -6798,9 +6321,9 @@ dependencies = [
  "pallet-authority-discovery",
  "pallet-authorship 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "pallet-babe",
- "pallet-bridge-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "pallet-bridge-grandpa 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "pallet-bridge-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "pallet-bridge-dispatch",
+ "pallet-bridge-grandpa",
+ "pallet-bridge-messages",
  "pallet-election-provider-multi-phase",
  "pallet-grandpa",
  "pallet-im-online 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -7664,7 +7187,7 @@ source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=
 dependencies = [
  "async-std",
  "async-trait",
- "bp-header-chain 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-header-chain",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "finality-relay",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -10178,10 +9701,10 @@ dependencies = [
  "anyhow",
  "async-std",
  "async-trait",
- "bp-header-chain 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-header-chain",
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-runtime-common 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bridge-runtime-common",
  "finality-grandpa",
  "finality-relay",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -10189,7 +9712,7 @@ dependencies = [
  "log",
  "messages-relay",
  "num-traits 0.2.14",
- "pallet-bridge-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "pallet-bridge-messages",
  "parity-scale-codec",
  "relay-substrate-client",
  "relay-utils",
@@ -10399,19 +9922,19 @@ version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-trait",
- "bp-header-chain 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-header-chain",
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bridge-primitives 0.11.6",
- "bridge-runtime-common 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bridge-runtime-common",
  "bridge-traits",
  "common-primitives 0.11.6",
  "component-crab-s2s",
  "component-darwinia-s2s",
  "component-subscan",
  "crab-runtime",
+ "darwinia-common-runtime",
  "darwinia-runtime",
- "darwinia-runtime-common",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "futures 0.3.17",
  "futures-timer",
@@ -10419,7 +9942,7 @@ dependencies = [
  "lifeline",
  "log",
  "messages-relay",
- "pallet-bridge-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "pallet-bridge-messages",
  "parity-scale-codec",
  "postage",
  "relay-substrate-client",
@@ -10475,11 +9998,11 @@ version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-trait",
- "bp-header-chain 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-header-chain",
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bridge-primitives 2.7.0",
- "bridge-runtime-common 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bridge-runtime-common",
  "bridge-traits",
  "common-primitives 2.7.0",
  "common-runtime",
@@ -10493,7 +10016,7 @@ dependencies = [
  "lifeline",
  "log",
  "messages-relay",
- "pallet-bridge-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "pallet-bridge-messages",
  "pangolin-runtime",
  "pangoro-runtime",
  "parity-scale-codec",
@@ -10728,27 +10251,6 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "to-ethereum-backing"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "array-bytes",
- "darwinia-relay-primitives 2.6.10",
- "darwinia-support 2.6.10",
- "ethabi 13.0.0",
- "ethereum-primitives 2.6.10",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "log",
- "parity-scale-codec",
- "serde 1.0.130",
- "serde_json",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "to-ethereum-backing"
 version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
@@ -10774,7 +10276,7 @@ version = "2.7.0"
 source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
 dependencies = [
  "array-bytes",
- "bp-message-dispatch 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-message-dispatch",
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "darwinia-support 2.7.0",
@@ -10792,18 +10294,6 @@ dependencies = [
  "serde_json",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "to-tron-backing"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "darwinia-support 2.6.10",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "parity-scale-codec",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 [[package]]
 name = "bsc-primitives"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "array-bytes",
  "ethbloom",
@@ -991,7 +991,7 @@ dependencies = [
 [[package]]
 name = "common-runtime"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-balances 2.7.0",
  "darwinia-support 2.7.0",
@@ -1337,7 +1337,7 @@ dependencies = [
 [[package]]
 name = "crab-runtime"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#4ea75571cce207c1989f31eeb83fe2a872e30529"
+source = "git+https://github.com/darwinia-network/darwinia.git?tag=v0.11.6-bridger#e958663969c69a23cebeafbf2a9df5b538260419"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -1623,7 +1623,7 @@ dependencies = [
 [[package]]
 name = "darwinia-balances"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "darwinia-balances-rpc-runtime-api 2.6.10",
  "darwinia-support 2.6.10",
@@ -1639,7 +1639,7 @@ dependencies = [
 [[package]]
 name = "darwinia-balances"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-balances-rpc-runtime-api 2.7.0",
  "darwinia-support 2.7.0",
@@ -1655,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "darwinia-balances-rpc-runtime-api"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "darwinia-support 2.6.10",
  "parity-scale-codec",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "darwinia-balances-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-support 2.7.0",
  "parity-scale-codec",
@@ -1679,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "darwinia-bridge-bsc"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "bsc-primitives",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "darwinia-bridge-ethereum"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "array-bytes",
  "blake2-rfc",
@@ -1718,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "darwinia-bridge-ethereum"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "array-bytes",
  "blake2-rfc",
@@ -1742,7 +1742,7 @@ dependencies = [
 [[package]]
 name = "darwinia-bridge-primitives"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#4ea75571cce207c1989f31eeb83fe2a872e30529"
+source = "git+https://github.com/darwinia-network/darwinia.git?tag=v0.11.6-bridger#e958663969c69a23cebeafbf2a9df5b538260419"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1792,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "darwinia-claims"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "array-bytes",
  "darwinia-support 2.6.10",
@@ -1810,7 +1810,7 @@ dependencies = [
 [[package]]
 name = "darwinia-claims"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "array-bytes",
  "darwinia-support 2.7.0",
@@ -1828,7 +1828,7 @@ dependencies = [
 [[package]]
 name = "darwinia-common-primitives"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#4ea75571cce207c1989f31eeb83fe2a872e30529"
+source = "git+https://github.com/darwinia-network/darwinia.git?tag=v0.11.6-bridger#e958663969c69a23cebeafbf2a9df5b538260419"
 dependencies = [
  "parity-scale-codec",
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "darwinia-common-runtime"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#4ea75571cce207c1989f31eeb83fe2a872e30529"
+source = "git+https://github.com/darwinia-network/darwinia.git?tag=v0.11.6-bridger#e958663969c69a23cebeafbf2a9df5b538260419"
 dependencies = [
  "darwinia-balances 2.6.10",
  "darwinia-common-primitives",
@@ -1858,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "darwinia-democracy"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "darwinia-support 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1873,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "darwinia-democracy"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "darwinia-elections-phragmen"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "darwinia-support 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "darwinia-elections-phragmen"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1922,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "array-bytes",
  "darwinia-balances 2.6.10",
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "array-bytes",
  "darwinia-balances 2.7.0",
@@ -1978,7 +1978,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-bridge-ethereum"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-evm 2.7.0",
  "darwinia-evm-precompile-utils",
@@ -1994,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-bridge-s2s"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "bp-message-dispatch",
  "bp-runtime",
@@ -2017,7 +2017,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-dispatch"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-evm 2.7.0",
  "darwinia-support 2.7.0",
@@ -2032,7 +2032,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-simple"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "dp-evm 2.6.10",
  "evm",
@@ -2044,7 +2044,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-simple"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "dp-evm 2.7.0",
  "evm",
@@ -2056,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-transfer"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "array-bytes",
  "darwinia-evm 2.6.10",
@@ -2081,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-transfer"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "array-bytes",
  "darwinia-evm 2.7.0",
@@ -2106,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-utils"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-evm-precompile-utils-macro",
  "darwinia-support 2.7.0",
@@ -2116,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-utils-macro"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "evm",
  "proc-macro2",
@@ -2129,7 +2129,7 @@ dependencies = [
 [[package]]
 name = "darwinia-fee-market"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "bitvec",
  "bp-messages",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "darwinia-fee-market"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "bitvec",
  "bp-messages",
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "darwinia-fee-market-rpc-runtime-api"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "bp-messages",
  "parity-scale-codec",
@@ -2188,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "darwinia-fee-market-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "bp-messages",
  "parity-scale-codec",
@@ -2201,7 +2201,7 @@ dependencies = [
 [[package]]
 name = "darwinia-header-mmr"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "ckb-merkle-mountain-range",
  "darwinia-header-mmr-rpc-runtime-api 2.6.6",
@@ -2221,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "darwinia-header-mmr"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "ckb-merkle-mountain-range",
  "darwinia-header-mmr-rpc-runtime-api 2.7.0",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "darwinia-header-mmr-rpc-runtime-api"
 version = "2.6.6"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "darwinia-support 2.6.10",
  "parity-scale-codec",
@@ -2254,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "darwinia-header-mmr-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-support 2.7.0",
  "parity-scale-codec",
@@ -2267,7 +2267,7 @@ dependencies = [
 [[package]]
 name = "darwinia-relay-authorities"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "darwinia-relay-primitives 2.6.10",
  "darwinia-support 2.6.10",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "darwinia-relay-authorities"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-relay-primitives 2.7.0",
  "darwinia-support 2.7.0",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "darwinia-relay-primitives"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
@@ -2308,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "darwinia-relay-primitives"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "darwinia-relayer-game"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "darwinia-relay-primitives 2.6.10",
  "darwinia-support 2.6.10",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "darwinia-relayer-game"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-relay-primitives 2.7.0",
  "darwinia-support 2.7.0",
@@ -2349,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "darwinia-runtime"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#4ea75571cce207c1989f31eeb83fe2a872e30529"
+source = "git+https://github.com/darwinia-network/darwinia.git?tag=v0.11.6-bridger#e958663969c69a23cebeafbf2a9df5b538260419"
 dependencies = [
  "bp-message-dispatch",
  "bp-messages",
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "darwinia-staking"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "darwinia-staking-rpc-runtime-api 2.6.10",
  "darwinia-support 2.6.10",
@@ -2461,7 +2461,7 @@ dependencies = [
 [[package]]
 name = "darwinia-staking"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-staking-rpc-runtime-api 2.7.0",
  "darwinia-support 2.7.0",
@@ -2485,7 +2485,7 @@ dependencies = [
 [[package]]
 name = "darwinia-staking-rpc-runtime-api"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "darwinia-support 2.6.10",
  "parity-scale-codec",
@@ -2497,7 +2497,7 @@ dependencies = [
 [[package]]
 name = "darwinia-staking-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-support 2.7.0",
  "parity-scale-codec",
@@ -2509,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "darwinia-support"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -2531,7 +2531,7 @@ dependencies = [
 [[package]]
 name = "darwinia-support"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -2553,7 +2553,7 @@ dependencies = [
 [[package]]
 name = "darwinia-vesting"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "darwinia-support 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "darwinia-vesting"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2684,7 +2684,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 [[package]]
 name = "dp-asset"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "ethereum-types",
  "parity-scale-codec",
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "dp-consensus"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2709,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "dp-consensus"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2723,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "dp-contract"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "bp-messages",
  "dp-asset",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "dp-evm"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "evm",
  "impl-trait-for-tuples",
@@ -2749,7 +2749,7 @@ dependencies = [
 [[package]]
 name = "dp-evm"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "evm",
  "impl-trait-for-tuples",
@@ -2762,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "dp-fee"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "bp-messages",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2774,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "dp-fee"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "bp-messages",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2786,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "dp-s2s"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -2802,17 +2802,17 @@ dependencies = [
 [[package]]
 name = "dp-storage"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 
 [[package]]
 name = "dp-storage"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 
 [[package]]
 name = "drml-bridge-primitives"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -2830,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "drml-common-primitives"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2845,7 +2845,7 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 [[package]]
 name = "dvm-ethereum"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "darwinia-evm 2.6.10",
  "darwinia-support 2.6.10",
@@ -2874,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "dvm-ethereum"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-evm 2.7.0",
  "darwinia-support 2.7.0",
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "dvm-rpc-runtime-api"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "darwinia-evm 2.6.10",
  "darwinia-support 2.6.10",
@@ -2921,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "dvm-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-evm 2.7.0",
  "darwinia-support 2.7.0",
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "ethereum-primitives"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "array-bytes",
  "ethash",
@@ -3170,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "ethereum-primitives"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "array-bytes",
  "ethash",
@@ -3669,7 +3669,7 @@ dependencies = [
 [[package]]
 name = "from-ethereum-issuing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "array-bytes",
  "darwinia-bridge-ethereum 2.7.0",
@@ -3693,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "from-substrate-issuing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -5526,7 +5526,7 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 [[package]]
 name = "merkle-patricia-trie"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "hashbrown 0.9.1",
  "keccak-hash",
@@ -5537,7 +5537,7 @@ dependencies = [
 [[package]]
 name = "merkle-patricia-trie"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "hashbrown 0.9.1",
  "keccak-hash",
@@ -5651,7 +5651,7 @@ dependencies = [
 [[package]]
 name = "module-transaction-pause"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -6499,7 +6499,7 @@ dependencies = [
 [[package]]
 name = "pangolin-runtime"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -6610,7 +6610,7 @@ dependencies = [
 [[package]]
 name = "pangoro-runtime"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "array-bytes",
  "bp-header-chain",
@@ -10577,7 +10577,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 [[package]]
 name = "to-ethereum-backing"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "array-bytes",
  "darwinia-relay-primitives 2.6.10",
@@ -10598,7 +10598,7 @@ dependencies = [
 [[package]]
 name = "to-ethereum-backing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "array-bytes",
  "darwinia-relay-primitives 2.7.0",
@@ -10619,7 +10619,7 @@ dependencies = [
 [[package]]
 name = "to-substrate-backing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -10645,7 +10645,7 @@ dependencies = [
 [[package]]
 name = "to-tron-backing"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-4#6c27522f0ca65f7734144482bc8215c1eb4c3ac7"
 dependencies = [
  "darwinia-support 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -10657,7 +10657,7 @@ dependencies = [
 [[package]]
 name = "to-tron-backing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=v2.7.0-1#65a867c33948bf545fea3ff73cc08b677bf4c549"
 dependencies = [
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,24 +639,9 @@ name = "bp-message-dispatch"
 version = "0.1.0"
 source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4#495a773403e5827bbf9d7b20d97333f673628db9"
 dependencies = [
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-runtime",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "bp-messages"
-version = "0.1.0"
-source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3#e26d59105acb795161881e49eb14992b8b0c22fa"
-dependencies = [
- "bitvec",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "serde 1.0.130",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
 
@@ -666,30 +651,13 @@ version = "0.1.0"
 source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4#495a773403e5827bbf9d7b20d97333f673628db9"
 dependencies = [
  "bitvec",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-runtime",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "serde 1.0.130",
  "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "bp-runtime"
-version = "0.1.0"
-source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3#e26d59105acb795161881e49eb14992b8b0c22fa"
-dependencies = [
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "hash-db",
- "num-traits 0.2.14",
- "parity-scale-codec",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-state-machine 0.9.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-trie 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
 ]
 
 [[package]]
@@ -739,49 +707,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "bridge-primitives"
-version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#db5f7808f496ce757326797a2b794a64669737db"
-dependencies = [
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-runtime-common",
- "common-primitives 0.11.6",
- "darwinia-fee-market 2.6.10",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "pallet-bridge-dispatch",
- "sp-api",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "bridge-primitives"
-version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
-dependencies = [
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-runtime-common",
- "common-primitives 2.7.0",
- "darwinia-fee-market 2.7.0",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "pallet-bridge-dispatch",
- "sp-api",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
 name = "bridge-runtime-common"
 version = "0.1.0"
 source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4#495a773403e5827bbf9d7b20d97333f673628db9"
 dependencies = [
  "bp-message-dispatch",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-messages",
+ "bp-runtime",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "hash-db",
  "pallet-bridge-dispatch",
@@ -826,7 +758,7 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 [[package]]
 name = "bsc-primitives"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "array-bytes",
  "ethbloom",
@@ -1057,32 +989,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "common-primitives"
-version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#db5f7808f496ce757326797a2b794a64669737db"
-dependencies = [
- "parity-scale-codec",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "common-primitives"
-version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
-dependencies = [
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
 name = "common-runtime"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
- "common-primitives 2.7.0",
  "darwinia-balances 2.7.0",
  "darwinia-support 2.7.0",
+ "drml-common-primitives",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "max-encoded-len",
@@ -1101,13 +1014,13 @@ version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-trait",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-primitives 0.11.6",
+ "bp-messages",
+ "bp-runtime",
  "bridge-traits",
- "common-primitives 0.11.6",
  "crab-runtime",
- "dp-fee 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
+ "darwinia-bridge-primitives",
+ "darwinia-common-primitives",
+ "dp-fee 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "headers-relay",
@@ -1128,14 +1041,14 @@ version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-trait",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-primitives 0.11.6",
+ "bp-messages",
+ "bp-runtime",
  "bridge-traits",
- "common-primitives 0.11.6",
- "darwinia-bridge-ethereum 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
+ "darwinia-bridge-ethereum 2.6.10",
+ "darwinia-bridge-primitives",
+ "darwinia-common-primitives",
  "darwinia-runtime",
- "dp-fee 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
+ "dp-fee 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "headers-relay",
@@ -1157,7 +1070,7 @@ dependencies = [
  "anyhow",
  "array-bytes",
  "async-trait",
- "bridge-primitives 0.4.8",
+ "bridge-primitives",
  "bridge-traits",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "jsonrpsee-types",
@@ -1211,13 +1124,13 @@ version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-trait",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-primitives 2.7.0",
+ "bp-messages",
+ "bp-runtime",
  "bridge-traits",
- "common-primitives 2.7.0",
  "darwinia-bridge-ethereum 2.7.0",
  "dp-fee 2.7.0",
+ "drml-bridge-primitives",
+ "drml-common-primitives",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "futures-test",
@@ -1265,12 +1178,12 @@ version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-trait",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-primitives 2.7.0",
+ "bp-messages",
+ "bp-runtime",
  "bridge-traits",
- "common-primitives 2.7.0",
  "dp-fee 2.7.0",
+ "drml-bridge-primitives",
+ "drml-common-primitives",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "headers-relay",
@@ -1424,18 +1337,19 @@ dependencies = [
 [[package]]
 name = "crab-runtime"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#db5f7808f496ce757326797a2b794a64669737db"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#4ea75571cce207c1989f31eeb83fe2a872e30529"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-primitives 0.11.6",
+ "bp-messages",
+ "bp-runtime",
  "bridge-runtime-common",
- "common-primitives 0.11.6",
  "darwinia-balances 2.6.10",
  "darwinia-balances-rpc-runtime-api 2.6.10",
+ "darwinia-bridge-primitives",
  "darwinia-claims 2.6.10",
+ "darwinia-common-primitives",
+ "darwinia-common-runtime",
  "darwinia-democracy 2.6.10",
  "darwinia-elections-phragmen 2.6.10",
  "darwinia-evm 2.6.10",
@@ -1445,15 +1359,14 @@ dependencies = [
  "darwinia-fee-market-rpc-runtime-api 2.6.10",
  "darwinia-header-mmr 2.6.10",
  "darwinia-header-mmr-rpc-runtime-api 2.6.6",
- "darwinia-runtime-common",
  "darwinia-staking 2.6.10",
  "darwinia-staking-rpc-runtime-api 2.6.10",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "darwinia-vesting 2.6.10",
  "dp-evm 2.6.10",
  "dvm-ethereum 2.6.10",
  "dvm-rpc-runtime-api 2.6.10",
- "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "ethereum-primitives 2.6.10",
  "evm",
  "frame-executive",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1710,10 +1623,10 @@ dependencies = [
 [[package]]
 name = "darwinia-balances"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "darwinia-balances-rpc-runtime-api 2.6.10",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "log",
@@ -1726,7 +1639,7 @@ dependencies = [
 [[package]]
 name = "darwinia-balances"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-balances-rpc-runtime-api 2.7.0",
  "darwinia-support 2.7.0",
@@ -1742,9 +1655,9 @@ dependencies = [
 [[package]]
 name = "darwinia-balances-rpc-runtime-api"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "parity-scale-codec",
  "serde 1.0.130",
  "sp-api",
@@ -1754,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "darwinia-balances-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-support 2.7.0",
  "parity-scale-codec",
@@ -1766,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "darwinia-bridge-bsc"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "bsc-primitives",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1781,39 +1694,15 @@ dependencies = [
 [[package]]
 name = "darwinia-bridge-ethereum"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "array-bytes",
  "blake2-rfc",
  "ckb-merkle-mountain-range",
- "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
- "darwinia-relayer-game 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
- "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
- "ethereum-types",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "parity-scale-codec",
- "rlp 0.5.1",
- "serde 1.0.130",
- "serde_json",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-bridge-ethereum"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
-dependencies = [
- "array-bytes",
- "blake2-rfc",
- "ckb-merkle-mountain-range",
- "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
- "darwinia-relayer-game 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
- "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-relay-primitives 2.6.10",
+ "darwinia-relayer-game 2.6.10",
+ "darwinia-support 2.6.10",
+ "ethereum-primitives 2.6.10",
  "ethereum-types",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1829,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "darwinia-bridge-ethereum"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "array-bytes",
  "blake2-rfc",
@@ -1851,12 +1740,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "darwinia-bridge-primitives"
+version = "0.11.6"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#4ea75571cce207c1989f31eeb83fe2a872e30529"
+dependencies = [
+ "bp-messages",
+ "bp-runtime",
+ "bridge-runtime-common",
+ "darwinia-common-primitives",
+ "darwinia-fee-market 2.6.10",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "pallet-bridge-dispatch",
+ "sp-api",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
 name = "darwinia-bridger"
 version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-recursion",
- "bridge-primitives 0.4.8",
+ "bridge-primitives",
  "bridge-traits",
  "colored",
  "component-state",
@@ -1885,10 +1792,10 @@ dependencies = [
 [[package]]
 name = "darwinia-claims"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "array-bytes",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "log",
@@ -1903,7 +1810,7 @@ dependencies = [
 [[package]]
 name = "darwinia-claims"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "array-bytes",
  "darwinia-support 2.7.0",
@@ -1919,11 +1826,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darwinia-common-primitives"
+version = "0.11.6"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#4ea75571cce207c1989f31eeb83fe2a872e30529"
+dependencies = [
+ "parity-scale-codec",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "darwinia-common-runtime"
+version = "0.11.6"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#4ea75571cce207c1989f31eeb83fe2a872e30529"
+dependencies = [
+ "darwinia-balances 2.6.10",
+ "darwinia-common-primitives",
+ "darwinia-support 2.6.10",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "max-encoded-len",
+ "pallet-authorship 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "pallet-transaction-payment",
+ "pallet-treasury",
+ "parity-scale-codec",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "static_assertions",
+]
+
+[[package]]
 name = "darwinia-democracy"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
@@ -1936,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "darwinia-democracy"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1951,9 +1888,9 @@ dependencies = [
 [[package]]
 name = "darwinia-elections-phragmen"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "log",
@@ -1968,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "darwinia-elections-phragmen"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1985,11 +1922,11 @@ dependencies = [
 [[package]]
 name = "darwinia-evm"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "array-bytes",
  "darwinia-balances 2.6.10",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "dp-evm 2.6.10",
  "evm",
  "evm-gasometer",
@@ -2013,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "array-bytes",
  "darwinia-balances 2.7.0",
@@ -2041,7 +1978,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-bridge-ethereum"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-evm 2.7.0",
  "darwinia-evm-precompile-utils",
@@ -2057,10 +1994,10 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-bridge-s2s"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "bp-message-dispatch",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-runtime",
  "darwinia-evm 2.7.0",
  "darwinia-evm-precompile-utils",
  "darwinia-support 2.7.0",
@@ -2080,7 +2017,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-dispatch"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-evm 2.7.0",
  "darwinia-support 2.7.0",
@@ -2095,7 +2032,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-simple"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "dp-evm 2.6.10",
  "evm",
@@ -2107,7 +2044,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-simple"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "dp-evm 2.7.0",
  "evm",
@@ -2119,11 +2056,11 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-transfer"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "array-bytes",
  "darwinia-evm 2.6.10",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "dp-evm 2.6.10",
  "ethabi 13.0.0",
  "ethereum-types",
@@ -2144,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-transfer"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "array-bytes",
  "darwinia-evm 2.7.0",
@@ -2169,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-utils"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-evm-precompile-utils-macro",
  "darwinia-support 2.7.0",
@@ -2179,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-utils-macro"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "evm",
  "proc-macro2",
@@ -2192,13 +2129,13 @@ dependencies = [
 [[package]]
 name = "darwinia-fee-market"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "bitvec",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
- "dp-fee 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "bp-messages",
+ "bp-runtime",
+ "darwinia-support 2.6.10",
+ "dp-fee 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "log",
@@ -2215,11 +2152,11 @@ dependencies = [
 [[package]]
 name = "darwinia-fee-market"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "bitvec",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-messages",
+ "bp-runtime",
  "darwinia-support 2.7.0",
  "dp-fee 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2238,9 +2175,9 @@ dependencies = [
 [[package]]
 name = "darwinia-fee-market-rpc-runtime-api"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-messages",
  "parity-scale-codec",
  "serde 1.0.130",
  "sp-api",
@@ -2251,9 +2188,9 @@ dependencies = [
 [[package]]
 name = "darwinia-fee-market-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-messages",
  "parity-scale-codec",
  "serde 1.0.130",
  "sp-api",
@@ -2264,12 +2201,12 @@ dependencies = [
 [[package]]
 name = "darwinia-header-mmr"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "ckb-merkle-mountain-range",
  "darwinia-header-mmr-rpc-runtime-api 2.6.6",
- "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-relay-primitives 2.6.10",
+ "darwinia-support 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "log",
@@ -2284,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "darwinia-header-mmr"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "ckb-merkle-mountain-range",
  "darwinia-header-mmr-rpc-runtime-api 2.7.0",
@@ -2304,9 +2241,9 @@ dependencies = [
 [[package]]
 name = "darwinia-header-mmr-rpc-runtime-api"
 version = "2.6.6"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "parity-scale-codec",
  "serde 1.0.130",
  "sp-api",
@@ -2317,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "darwinia-header-mmr-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-support 2.7.0",
  "parity-scale-codec",
@@ -2330,10 +2267,10 @@ dependencies = [
 [[package]]
 name = "darwinia-relay-authorities"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
- "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-relay-primitives 2.6.10",
+ "darwinia-support 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "log",
@@ -2345,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "darwinia-relay-authorities"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-relay-primitives 2.7.0",
  "darwinia-support 2.7.0",
@@ -2360,18 +2297,7 @@ dependencies = [
 [[package]]
 name = "darwinia-relay-primitives"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "parity-scale-codec",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-relay-primitives"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
@@ -2382,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "darwinia-relay-primitives"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
@@ -2393,25 +2319,10 @@ dependencies = [
 [[package]]
 name = "darwinia-relayer-game"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
- "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "log",
- "parity-scale-codec",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-relayer-game"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
-dependencies = [
- "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-relay-primitives 2.6.10",
+ "darwinia-support 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "log",
@@ -2423,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "darwinia-relayer-game"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-relay-primitives 2.7.0",
  "darwinia-support 2.7.0",
@@ -2438,17 +2349,18 @@ dependencies = [
 [[package]]
 name = "darwinia-runtime"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#db5f7808f496ce757326797a2b794a64669737db"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#4ea75571cce207c1989f31eeb83fe2a872e30529"
 dependencies = [
  "bp-message-dispatch",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-primitives 0.11.6",
+ "bp-messages",
+ "bp-runtime",
  "bridge-runtime-common",
- "common-primitives 0.11.6",
  "darwinia-balances 2.6.10",
  "darwinia-balances-rpc-runtime-api 2.6.10",
- "darwinia-bridge-ethereum 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-bridge-ethereum 2.6.10",
+ "darwinia-bridge-primitives",
+ "darwinia-common-primitives",
+ "darwinia-common-runtime",
  "darwinia-democracy 2.6.10",
  "darwinia-elections-phragmen 2.6.10",
  "darwinia-fee-market 2.6.10",
@@ -2456,14 +2368,13 @@ dependencies = [
  "darwinia-header-mmr 2.6.10",
  "darwinia-header-mmr-rpc-runtime-api 2.6.6",
  "darwinia-relay-authorities 2.6.10",
- "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
- "darwinia-relayer-game 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
- "darwinia-runtime-common",
+ "darwinia-relay-primitives 2.6.10",
+ "darwinia-relayer-game 2.6.10",
  "darwinia-staking 2.6.10",
  "darwinia-staking-rpc-runtime-api 2.6.10",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "darwinia-vesting 2.6.10",
- "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "ethereum-primitives 2.6.10",
  "frame-executive",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2524,33 +2435,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "darwinia-runtime-common"
-version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#db5f7808f496ce757326797a2b794a64669737db"
-dependencies = [
- "common-primitives 0.11.6",
- "darwinia-balances 2.6.10",
- "darwinia-staking 2.6.10",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "max-encoded-len",
- "pallet-authorship 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "pallet-transaction-payment",
- "pallet-treasury",
- "parity-scale-codec",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "static_assertions",
-]
-
-[[package]]
 name = "darwinia-staking"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "darwinia-staking-rpc-runtime-api 2.6.10",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "frame-election-provider-support",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2571,7 +2461,7 @@ dependencies = [
 [[package]]
 name = "darwinia-staking"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-staking-rpc-runtime-api 2.7.0",
  "darwinia-support 2.7.0",
@@ -2595,9 +2485,9 @@ dependencies = [
 [[package]]
 name = "darwinia-staking-rpc-runtime-api"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "parity-scale-codec",
  "serde 1.0.130",
  "sp-api",
@@ -2607,7 +2497,7 @@ dependencies = [
 [[package]]
 name = "darwinia-staking-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-support 2.7.0",
  "parity-scale-codec",
@@ -2619,34 +2509,12 @@ dependencies = [
 [[package]]
 name = "darwinia-support"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
+ "bp-messages",
+ "bp-runtime",
  "ethereum",
- "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "impl-trait-for-tuples",
- "max-encoded-len",
- "num-traits 0.2.14",
- "parity-scale-codec",
- "sha3 0.9.1",
- "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-io 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "darwinia-support"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
-dependencies = [
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "ethereum",
- "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "ethereum-primitives 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "impl-trait-for-tuples",
@@ -2663,10 +2531,10 @@ dependencies = [
 [[package]]
 name = "darwinia-support"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-messages",
+ "bp-runtime",
  "ethereum",
  "ethereum-primitives 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2685,9 +2553,9 @@ dependencies = [
 [[package]]
 name = "darwinia-vesting"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
@@ -2698,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "darwinia-vesting"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2816,7 +2684,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 [[package]]
 name = "dp-asset"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "ethereum-types",
  "parity-scale-codec",
@@ -2827,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "dp-consensus"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2841,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "dp-consensus"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2855,9 +2723,9 @@ dependencies = [
 [[package]]
 name = "dp-contract"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-messages",
  "dp-asset",
  "ethabi 13.0.0",
  "ethereum-primitives 2.7.0",
@@ -2868,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "dp-evm"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "evm",
  "impl-trait-for-tuples",
@@ -2881,7 +2749,7 @@ dependencies = [
 [[package]]
 name = "dp-evm"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "evm",
  "impl-trait-for-tuples",
@@ -2894,21 +2762,9 @@ dependencies = [
 [[package]]
 name = "dp-fee"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-3)",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "parity-scale-codec",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "dp-fee"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
-dependencies = [
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-messages",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2918,9 +2774,9 @@ dependencies = [
 [[package]]
 name = "dp-fee"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-messages",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2930,11 +2786,11 @@ dependencies = [
 [[package]]
 name = "dp-s2s"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-runtime",
  "dp-asset",
  "dp-contract",
  "parity-scale-codec",
@@ -2946,12 +2802,39 @@ dependencies = [
 [[package]]
 name = "dp-storage"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 
 [[package]]
 name = "dp-storage"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+
+[[package]]
+name = "drml-bridge-primitives"
+version = "2.7.0"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+dependencies = [
+ "bp-messages",
+ "bp-runtime",
+ "bridge-runtime-common",
+ "darwinia-fee-market 2.7.0",
+ "drml-common-primitives",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "pallet-bridge-dispatch",
+ "sp-api",
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
+
+[[package]]
+name = "drml-common-primitives"
+version = "2.7.0"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
+dependencies = [
+ "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+]
 
 [[package]]
 name = "dtoa"
@@ -2962,10 +2845,10 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 [[package]]
 name = "dvm-ethereum"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "darwinia-evm 2.6.10",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "dp-consensus 2.6.10",
  "dp-evm 2.6.10",
  "dp-storage 2.6.10",
@@ -2991,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "dvm-ethereum"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-evm 2.7.0",
  "darwinia-support 2.7.0",
@@ -3020,10 +2903,10 @@ dependencies = [
 [[package]]
 name = "dvm-rpc-runtime-api"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "darwinia-evm 2.6.10",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "dp-evm 2.6.10",
  "ethereum",
  "ethereum-types",
@@ -3038,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "dvm-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-evm 2.7.0",
  "darwinia-support 2.7.0",
@@ -3268,33 +3151,14 @@ dependencies = [
 [[package]]
 name = "ethereum-primitives"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "array-bytes",
  "ethash",
  "ethbloom",
  "ethereum-types",
  "keccak-hash",
- "merkle-patricia-trie 2.6.10 (git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3)",
- "parity-scale-codec",
- "rlp 0.5.1",
- "rlp-derive",
- "serde 1.0.130",
- "sp-debug-derive 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subhasher",
-]
-
-[[package]]
-name = "ethereum-primitives"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
-dependencies = [
- "array-bytes",
- "ethash",
- "ethbloom",
- "ethereum-types",
- "keccak-hash",
- "merkle-patricia-trie 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "merkle-patricia-trie 2.6.10",
  "parity-scale-codec",
  "rlp 0.5.1",
  "rlp-derive",
@@ -3306,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "ethereum-primitives"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "array-bytes",
  "ethash",
@@ -3805,7 +3669,7 @@ dependencies = [
 [[package]]
 name = "from-ethereum-issuing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "array-bytes",
  "darwinia-bridge-ethereum 2.7.0",
@@ -3829,12 +3693,12 @@ dependencies = [
 [[package]]
 name = "from-substrate-issuing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-messages",
+ "bp-runtime",
  "darwinia-evm 2.7.0",
  "darwinia-support 2.7.0",
  "dp-asset",
@@ -5662,18 +5526,7 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 [[package]]
 name = "merkle-patricia-trie"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?tag=darwinia-v0.11.6-3#ed73e1a2619107dbe02ce636f174c4570552c946"
-dependencies = [
- "hashbrown 0.9.1",
- "keccak-hash",
- "rlp 0.5.1",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
-]
-
-[[package]]
-name = "merkle-patricia-trie"
-version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "hashbrown 0.9.1",
  "keccak-hash",
@@ -5684,7 +5537,7 @@ dependencies = [
 [[package]]
 name = "merkle-patricia-trie"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "hashbrown 0.9.1",
  "keccak-hash",
@@ -5712,8 +5565,8 @@ dependencies = [
  "anyhow",
  "async-std",
  "async-trait",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-messages",
+ "bp-runtime",
  "futures 0.3.17",
  "hex",
  "log",
@@ -5798,7 +5651,7 @@ dependencies = [
 [[package]]
 name = "module-transaction-pause"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -6195,7 +6048,7 @@ version = "0.1.0"
 source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4#495a773403e5827bbf9d7b20d97333f673628db9"
 dependencies = [
  "bp-message-dispatch",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-runtime",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "log",
@@ -6211,7 +6064,7 @@ version = "0.1.0"
 source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4#495a773403e5827bbf9d7b20d97333f673628db9"
 dependencies = [
  "bp-header-chain",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-runtime",
  "bp-test-utils",
  "finality-grandpa",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -6233,8 +6086,8 @@ source = "git+https://github.com/darwinia-network/parity-bridges-common.git?tag=
 dependencies = [
  "bitvec",
  "bp-message-dispatch",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-messages",
+ "bp-runtime",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "log",
@@ -6646,15 +6499,13 @@ dependencies = [
 [[package]]
 name = "pangolin-runtime"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-primitives 2.7.0",
+ "bp-messages",
+ "bp-runtime",
  "bridge-runtime-common",
- "common-primitives 2.7.0",
  "common-runtime",
  "darwinia-balances 2.7.0",
  "darwinia-balances-rpc-runtime-api 2.7.0",
@@ -6685,6 +6536,8 @@ dependencies = [
  "dp-evm 2.7.0",
  "dp-fee 2.7.0",
  "dp-s2s",
+ "drml-bridge-primitives",
+ "drml-common-primitives",
  "dvm-ethereum 2.7.0",
  "dvm-rpc-runtime-api 2.7.0",
  "ethereum-primitives 2.7.0",
@@ -6757,16 +6610,14 @@ dependencies = [
 [[package]]
 name = "pangoro-runtime"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "array-bytes",
  "bp-header-chain",
  "bp-message-dispatch",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-primitives 2.7.0",
+ "bp-messages",
+ "bp-runtime",
  "bridge-runtime-common",
- "common-primitives 2.7.0",
  "common-runtime",
  "darwinia-balances 2.7.0",
  "darwinia-balances-rpc-runtime-api 2.7.0",
@@ -6778,6 +6629,8 @@ dependencies = [
  "dp-asset",
  "dp-fee 2.7.0",
  "dp-s2s",
+ "drml-bridge-primitives",
+ "drml-common-primitives",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
@@ -7658,7 +7511,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bp-header-chain",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-runtime",
  "finality-relay",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -10174,8 +10027,8 @@ dependencies = [
  "async-std",
  "async-trait",
  "bp-header-chain",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-messages",
+ "bp-runtime",
  "bridge-runtime-common",
  "finality-grandpa",
  "finality-relay",
@@ -10274,7 +10127,7 @@ name = "support-ethereum"
 version = "0.4.8"
 dependencies = [
  "anyhow",
- "bridge-primitives 0.4.8",
+ "bridge-primitives",
  "frame-support 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "pallet-im-online 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -10305,7 +10158,7 @@ name = "support-proc-macro"
 version = "0.4.8"
 dependencies = [
  "anyhow",
- "bridge-primitives 0.4.8",
+ "bridge-primitives",
  "proc-macro2",
  "proc_macro_roids",
  "quote",
@@ -10395,18 +10248,18 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bp-header-chain",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-primitives 0.11.6",
+ "bp-messages",
+ "bp-runtime",
  "bridge-runtime-common",
  "bridge-traits",
- "common-primitives 0.11.6",
  "component-crab-s2s",
  "component-darwinia-s2s",
  "component-subscan",
  "crab-runtime",
+ "darwinia-bridge-primitives",
+ "darwinia-common-primitives",
+ "darwinia-common-runtime",
  "darwinia-runtime",
- "darwinia-runtime-common",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "futures 0.3.17",
  "futures-timer",
@@ -10471,16 +10324,16 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bp-header-chain",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bridge-primitives 2.7.0",
+ "bp-messages",
+ "bp-runtime",
  "bridge-runtime-common",
  "bridge-traits",
- "common-primitives 2.7.0",
  "common-runtime",
  "component-pangolin-s2s",
  "component-pangoro-s2s",
  "component-subscan",
+ "drml-bridge-primitives",
+ "drml-common-primitives",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "futures 0.3.17",
  "futures-timer",
@@ -10724,13 +10577,13 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 [[package]]
 name = "to-ethereum-backing"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
  "array-bytes",
- "darwinia-relay-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-relay-primitives 2.6.10",
+ "darwinia-support 2.6.10",
  "ethabi 13.0.0",
- "ethereum-primitives 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "ethereum-primitives 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "log",
@@ -10745,7 +10598,7 @@ dependencies = [
 [[package]]
 name = "to-ethereum-backing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "array-bytes",
  "darwinia-relay-primitives 2.7.0",
@@ -10766,12 +10619,12 @@ dependencies = [
 [[package]]
 name = "to-substrate-backing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
- "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
- "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
+ "bp-messages",
+ "bp-runtime",
  "darwinia-support 2.7.0",
  "dp-asset",
  "dp-contract",
@@ -10792,9 +10645,9 @@ dependencies = [
 [[package]]
 name = "to-tron-backing"
 version = "2.6.10"
-source = "git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps-darwinia#ac559d47c4fa4dbaf4c807015c4461d7a8464c80"
 dependencies = [
- "darwinia-support 2.6.10 (git+https://github.com/darwinia-network/darwinia-common?branch=bump-deps-darwinia)",
+ "darwinia-support 2.6.10",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
@@ -10804,7 +10657,7 @@ dependencies = [
 [[package]]
 name = "to-tron-backing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#d36cfb35c5d0b57104a0724d3825c04284de92e2"
 dependencies = [
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -11107,7 +10960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
  "cfg-if 1.0.0",
- "rand 0.8.4",
+ "rand 0.3.23",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 [[package]]
 name = "bridge-primitives"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#ec6d5faafbd5c57b0316163dcaecb52dae620e3c"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#b3d1b1ef4adbca5a912cce02f137a5593ee2ce4d"
 dependencies = [
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "bridge-primitives"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
@@ -826,7 +826,7 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 [[package]]
 name = "bsc-primitives"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
  "ethbloom",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "common-primitives"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#ec6d5faafbd5c57b0316163dcaecb52dae620e3c"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#b3d1b1ef4adbca5a912cce02f137a5593ee2ce4d"
 dependencies = [
  "parity-scale-codec",
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "common-primitives"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "sp-core 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "common-runtime"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "common-primitives 2.7.0",
  "darwinia-balances",
@@ -1424,7 +1424,7 @@ dependencies = [
 [[package]]
 name = "crab-runtime"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#ec6d5faafbd5c57b0316163dcaecb52dae620e3c"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#b3d1b1ef4adbca5a912cce02f137a5593ee2ce4d"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -1436,7 +1436,6 @@ dependencies = [
  "darwinia-balances",
  "darwinia-balances-rpc-runtime-api",
  "darwinia-claims",
- "darwinia-common-runtime",
  "darwinia-democracy",
  "darwinia-elections-phragmen",
  "darwinia-evm",
@@ -1446,6 +1445,7 @@ dependencies = [
  "darwinia-fee-market-rpc-runtime-api",
  "darwinia-header-mmr",
  "darwinia-header-mmr-rpc-runtime-api",
+ "darwinia-runtime-common",
  "darwinia-staking",
  "darwinia-staking-rpc-runtime-api",
  "darwinia-support 2.7.0",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "darwinia-balances"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-balances-rpc-runtime-api",
  "darwinia-support 2.7.0",
@@ -1726,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "darwinia-balances-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-support 2.7.0",
  "parity-scale-codec",
@@ -1738,7 +1738,7 @@ dependencies = [
 [[package]]
 name = "darwinia-bridge-bsc"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "bsc-primitives",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1777,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "darwinia-bridge-ethereum"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
  "blake2-rfc",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "darwinia-claims"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
  "darwinia-support 2.7.0",
@@ -1849,29 +1849,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "darwinia-common-runtime"
-version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#ec6d5faafbd5c57b0316163dcaecb52dae620e3c"
-dependencies = [
- "common-primitives 0.11.6",
- "darwinia-balances",
- "darwinia-support 2.7.0",
- "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "max-encoded-len",
- "pallet-authorship 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "pallet-transaction-payment",
- "pallet-treasury",
- "parity-scale-codec",
- "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
- "static_assertions",
-]
-
-[[package]]
 name = "darwinia-democracy"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1886,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "darwinia-elections-phragmen"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -1903,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
  "darwinia-balances",
@@ -1931,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-bridge-ethereum"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-evm",
  "darwinia-evm-precompile-utils",
@@ -1947,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-bridge-s2s"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "bp-message-dispatch",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
@@ -1970,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-dispatch"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-evm",
  "darwinia-support 2.7.0",
@@ -1985,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-simple"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "dp-evm",
  "evm",
@@ -1997,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-transfer"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
  "darwinia-evm",
@@ -2022,7 +2002,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-utils"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-evm-precompile-utils-macro",
  "darwinia-support 2.7.0",
@@ -2032,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "darwinia-evm-precompile-utils-macro"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "evm",
  "proc-macro2",
@@ -2045,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "darwinia-fee-market"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "bitvec",
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
@@ -2068,7 +2048,7 @@ dependencies = [
 [[package]]
 name = "darwinia-fee-market-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "parity-scale-codec",
@@ -2081,7 +2061,7 @@ dependencies = [
 [[package]]
 name = "darwinia-header-mmr"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "ckb-merkle-mountain-range",
  "darwinia-header-mmr-rpc-runtime-api",
@@ -2101,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "darwinia-header-mmr-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-support 2.7.0",
  "parity-scale-codec",
@@ -2114,7 +2094,7 @@ dependencies = [
 [[package]]
 name = "darwinia-relay-authorities"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-relay-primitives 2.7.0",
  "darwinia-support 2.7.0",
@@ -2140,7 +2120,7 @@ dependencies = [
 [[package]]
 name = "darwinia-relay-primitives"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "parity-scale-codec",
@@ -2166,7 +2146,7 @@ dependencies = [
 [[package]]
 name = "darwinia-relayer-game"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-relay-primitives 2.7.0",
  "darwinia-support 2.7.0",
@@ -2181,7 +2161,7 @@ dependencies = [
 [[package]]
 name = "darwinia-runtime"
 version = "0.11.6"
-source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#ec6d5faafbd5c57b0316163dcaecb52dae620e3c"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#b3d1b1ef4adbca5a912cce02f137a5593ee2ce4d"
 dependencies = [
  "bp-message-dispatch",
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
@@ -2192,7 +2172,6 @@ dependencies = [
  "darwinia-balances",
  "darwinia-balances-rpc-runtime-api",
  "darwinia-bridge-ethereum 2.7.0",
- "darwinia-common-runtime",
  "darwinia-democracy",
  "darwinia-elections-phragmen",
  "darwinia-fee-market",
@@ -2202,6 +2181,7 @@ dependencies = [
  "darwinia-relay-authorities",
  "darwinia-relay-primitives 2.7.0",
  "darwinia-relayer-game 2.7.0",
+ "darwinia-runtime-common",
  "darwinia-staking",
  "darwinia-staking-rpc-runtime-api",
  "darwinia-support 2.7.0",
@@ -2267,9 +2247,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "darwinia-runtime-common"
+version = "0.11.6"
+source = "git+https://github.com/darwinia-network/darwinia.git?branch=bump-deps#b3d1b1ef4adbca5a912cce02f137a5593ee2ce4d"
+dependencies = [
+ "common-primitives 0.11.6",
+ "darwinia-balances",
+ "darwinia-staking",
+ "darwinia-support 2.7.0",
+ "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "max-encoded-len",
+ "pallet-authorship 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "pallet-transaction-payment",
+ "pallet-treasury",
+ "parity-scale-codec",
+ "sp-runtime 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "sp-std 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "static_assertions",
+]
+
+[[package]]
 name = "darwinia-staking"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-staking-rpc-runtime-api",
  "darwinia-support 2.7.0",
@@ -2293,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "darwinia-staking-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-support 2.7.0",
  "parity-scale-codec",
@@ -2327,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "darwinia-support"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "bp-runtime 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
@@ -2349,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "darwinia-vesting"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2467,7 +2468,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 [[package]]
 name = "dp-asset"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "ethereum-types",
  "parity-scale-codec",
@@ -2478,7 +2479,7 @@ dependencies = [
 [[package]]
 name = "dp-consensus"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2492,7 +2493,7 @@ dependencies = [
 [[package]]
 name = "dp-contract"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "dp-asset",
@@ -2505,7 +2506,7 @@ dependencies = [
 [[package]]
 name = "dp-evm"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "evm",
  "impl-trait-for-tuples",
@@ -2530,7 +2531,7 @@ dependencies = [
 [[package]]
 name = "dp-fee"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "bp-messages 0.1.0 (git+https://github.com/darwinia-network/parity-bridges-common.git?tag=darwinia-v0.11.6-4)",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -2542,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "dp-s2s"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -2558,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "dp-storage"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 
 [[package]]
 name = "dtoa"
@@ -2569,7 +2570,7 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 [[package]]
 name = "dvm-ethereum"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-evm",
  "darwinia-support 2.7.0",
@@ -2598,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "dvm-rpc-runtime-api"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-evm",
  "darwinia-support 2.7.0",
@@ -2847,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "ethereum-primitives"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
  "ethash",
@@ -3346,7 +3347,7 @@ dependencies = [
 [[package]]
 name = "from-ethereum-issuing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
  "darwinia-bridge-ethereum 2.7.0",
@@ -3370,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "from-substrate-issuing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -3573,7 +3574,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
- "typenum",
+ "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3582,7 +3583,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
- "typenum",
+ "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check",
 ]
 
@@ -4915,7 +4916,7 @@ dependencies = [
  "rand 0.7.3",
  "sha2 0.8.2",
  "subtle 2.4.1",
- "typenum",
+ "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4934,7 +4935,7 @@ dependencies = [
  "rand 0.7.3",
  "serde 1.0.130",
  "sha2 0.9.8",
- "typenum",
+ "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5214,7 +5215,7 @@ dependencies = [
 [[package]]
 name = "merkle-patricia-trie"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "hashbrown 0.9.1",
  "keccak-hash",
@@ -5328,7 +5329,7 @@ dependencies = [
 [[package]]
 name = "module-transaction-pause"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -5414,7 +5415,7 @@ dependencies = [
  "rand 0.8.4",
  "rand_distr",
  "simba",
- "typenum",
+ "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6176,7 +6177,7 @@ dependencies = [
 [[package]]
 name = "pangolin-runtime"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -6287,7 +6288,7 @@ dependencies = [
 [[package]]
 name = "pangoro-runtime"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
  "bp-header-chain",
@@ -6379,9 +6380,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
+checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
  "arrayvec 0.7.1",
  "bitvec",
@@ -6393,9 +6394,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40dbbfef7f0a1143c5b06e0d76a6278e25dac0bc1af4be51a0fbb73f07e7ad09"
+checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -9672,11 +9673,13 @@ dependencies = [
 
 [[package]]
 name = "substrate-fixed"
-version = "0.5.6"
-source = "git+https://github.com/encointer/substrate-fixed?branch=master#b33d186888c60f38adafcfc0ec3a21aab263aef1"
+version = "0.5.7"
+source = "git+https://github.com/encointer/substrate-fixed?branch=master#2f353acee3c7cf7a386863a89fc6cb805048561f"
 dependencies = [
  "parity-scale-codec",
- "typenum",
+ "scale-info",
+ "serde 1.0.130",
+ "typenum 1.14.0 (git+https://github.com/encointer/typenum)",
 ]
 
 [[package]]
@@ -9933,8 +9936,8 @@ dependencies = [
  "component-darwinia-s2s",
  "component-subscan",
  "crab-runtime",
- "darwinia-common-runtime",
  "darwinia-runtime",
+ "darwinia-runtime-common",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "futures 0.3.17",
  "futures-timer",
@@ -10252,7 +10255,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 [[package]]
 name = "to-ethereum-backing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
  "darwinia-relay-primitives 2.7.0",
@@ -10273,7 +10276,7 @@ dependencies = [
 [[package]]
 name = "to-substrate-backing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -10299,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "to-tron-backing"
 version = "2.7.0"
-source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#dee6b8606aac443d4199d55797aaa3ac6202d74b"
+source = "git+https://github.com/darwinia-network/darwinia-common.git?branch=bump-deps#2799b0afede7de6ac67c646fcdd7227d68909e08"
 dependencies = [
  "darwinia-support 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
@@ -10601,8 +10604,8 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 0.1.10",
- "rand 0.3.23",
+ "cfg-if 1.0.0",
+ "rand 0.8.4",
  "static_assertions",
 ]
 
@@ -10611,6 +10614,14 @@ name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+
+[[package]]
+name = "typenum"
+version = "1.14.0"
+source = "git+https://github.com/encointer/typenum#ec35bb80fcfb495de2e1f6966381c3f85e8a6509"
+dependencies = [
+ "scale-info",
+]
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,6 +1283,7 @@ dependencies = [
  "dp-fee 2.7.0",
  "frame-support 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
  "frame-system 3.0.0 (git+https://github.com/darwinia-network/substrate.git?tag=darwinia-v0.11.6-1)",
+ "futures 0.3.17",
  "futures-test",
  "headers-relay",
  "log",

--- a/components/client-crab-s2s/Cargo.toml
+++ b/components/client-crab-s2s/Cargo.toml
@@ -33,10 +33,10 @@ bp-messages            = { git = "https://github.com/darwinia-network/parity-bri
 bp-runtime             = { git = "https://github.com/darwinia-network/parity-bridges-common.git", tag = "darwinia-v0.11.6-4" }
 
 ## Bridge dependencies
-crab-runtime            = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-common-primitives       = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-bridge-primitives       = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-dp-fee                  = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "darwinia-v0.11.6-3" }
+crab-runtime               = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+darwinia-common-primitives = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+darwinia-bridge-primitives = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+dp-fee                     = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps-darwinia" }
 
 
 

--- a/components/client-crab-s2s/Cargo.toml
+++ b/components/client-crab-s2s/Cargo.toml
@@ -33,9 +33,9 @@ bp-messages            = { git = "https://github.com/darwinia-network/parity-bri
 bp-runtime             = { git = "https://github.com/darwinia-network/parity-bridges-common.git", tag = "darwinia-v0.11.6-4" }
 
 ## Bridge dependencies
-crab-runtime            = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6" }
-common-primitives       = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6" }
-bridge-primitives       = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6" }
+crab-runtime            = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+common-primitives       = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+bridge-primitives       = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
 dp-fee                  = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "darwinia-v0.11.6-3" }
 
 

--- a/components/client-crab-s2s/Cargo.toml
+++ b/components/client-crab-s2s/Cargo.toml
@@ -33,10 +33,10 @@ bp-messages            = { git = "https://github.com/darwinia-network/parity-bri
 bp-runtime             = { git = "https://github.com/darwinia-network/parity-bridges-common.git", tag = "darwinia-v0.11.6-4" }
 
 ## Bridge dependencies
-crab-runtime               = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-darwinia-common-primitives = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-darwinia-bridge-primitives = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-dp-fee                     = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps-darwinia" }
+crab-runtime               = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6-bridger" }
+darwinia-common-primitives = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6-bridger" }
+darwinia-bridge-primitives = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6-bridger" }
+dp-fee                     = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "darwinia-v0.11.6-4" }
 
 
 

--- a/components/client-crab-s2s/src/api.rs
+++ b/components/client-crab-s2s/src/api.rs
@@ -6,6 +6,7 @@ use common_primitives::BlockNumber;
 use dp_fee::{Order, Relayer};
 use relay_substrate_client::{ChainBase, Client, TransactionSignScheme, UnsignedTransaction};
 use relay_utils::relay_loop::Client as RelayLoopClient;
+use relay_utils::MaybeConnectionError;
 use sp_core::storage::StorageKey;
 use sp_core::{Bytes, Pair};
 
@@ -23,103 +24,110 @@ impl CrabApi {
 }
 
 impl CrabApi {
-    pub async fn client(&self) -> anyhow::Result<Client<CrabChain>> {
-        let mut client = self.client.clone();
-        client.reconnect().await?;
-        Ok(client)
-    }
-
     /// Query assigned relayers
-    pub async fn assigned_relayers(&self) -> anyhow::Result<Vec<Relayer<AccountId, Balance>>> {
-        Ok(self
-            .client()
-            .await?
-            .storage_value(
-                StorageKey(
-                    patch::storage_prefix("FeeMarket".as_bytes(), "AssignedRelayers".as_bytes())
-                        .to_vec(),
-                ),
-                None,
-            )
-            .await?
-            .unwrap_or_else(Vec::new))
+    pub async fn assigned_relayers(&mut self) -> anyhow::Result<Vec<Relayer<AccountId, Balance>>> {
+        let storage_key = StorageKey(
+            patch::storage_prefix("FeeMarket".as_bytes(), "AssignedRelayers".as_bytes()).to_vec(),
+        );
+        match self.client.storage_value(storage_key, None).await {
+            Ok(v) => Ok(v.unwrap_or_default()),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
     }
 
     /// Query order
     pub async fn order(
-        &self,
+        &mut self,
         laned_id: LaneId,
         message_nonce: MessageNonce,
     ) -> anyhow::Result<Option<Order<AccountId, BlockNumber, Balance>>> {
-        Ok(self
-            .client()
-            .await?
-            .storage_value(
-                bp_runtime::storage_map_final_key_blake2_128concat(
-                    "FeeMarket",
-                    "Orders",
-                    (laned_id, message_nonce).encode().as_slice(),
-                ),
-                None,
-            )
-            .await?)
+        let storage_key = bp_runtime::storage_map_final_key_blake2_128concat(
+            "FeeMarket",
+            "Orders",
+            (laned_id, message_nonce).encode().as_slice(),
+        );
+        match self.client.storage_value(storage_key.clone(), None).await {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
     }
 
     /// Query all relayers
-    pub async fn relayers(&self) -> anyhow::Result<Vec<AccountId>> {
-        Ok(self
-            .client()
-            .await?
-            .storage_value(
-                StorageKey(
-                    patch::storage_prefix("FeeMarket".as_bytes(), "Relayers".as_bytes()).to_vec(),
-                ),
-                None,
-            )
-            .await?
-            .unwrap_or_else(Vec::new))
+    pub async fn relayers(&mut self) -> anyhow::Result<Vec<AccountId>> {
+        let storage_key = StorageKey(
+            patch::storage_prefix("FeeMarket".as_bytes(), "Relayers".as_bytes()).to_vec(),
+        );
+        match self.client.storage_value(storage_key, None).await {
+            Ok(v) => Ok(v.unwrap_or_default()),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
     }
 
     /// Query relayer info by account id
     pub async fn relayer(
-        &self,
+        &mut self,
         account: AccountId,
     ) -> anyhow::Result<Option<Relayer<AccountId, Balance>>> {
-        Ok(self
-            .client()
-            .await?
-            .storage_value(
-                bp_runtime::storage_map_final_key_blake2_128concat(
-                    "FeeMarket",
-                    "RelayersMap",
-                    account.encode().as_slice(),
-                ),
-                None,
-            )
-            .await?)
+        let storage_key = bp_runtime::storage_map_final_key_blake2_128concat(
+            "FeeMarket",
+            "RelayersMap",
+            account.encode().as_slice(),
+        );
+        match self.client.storage_value(storage_key.clone(), None).await {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
     }
 
-    pub async fn is_relayer(&self, account: AccountId) -> anyhow::Result<bool> {
+    pub async fn is_relayer(&mut self, account: AccountId) -> anyhow::Result<bool> {
         self.relayer(account).await.map(|item| item.is_some())
     }
 
     /// Return number of the best finalized block.
     pub async fn best_finalized_header_number(
-        &self,
+        &mut self,
     ) -> anyhow::Result<common_primitives::BlockNumber> {
-        Ok(self.client().await?.best_finalized_header_number().await?)
+        match self.client.best_finalized_header_number().await {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
     }
 
     /// Update relay fee
     pub async fn update_relay_fee(
-        &self,
+        &mut self,
         signer: <CrabChain as TransactionSignScheme>::AccountKeyPair,
         amount: <CrabChain as ChainBase>::Balance,
     ) -> anyhow::Result<()> {
         let signer_id = (*signer.public().as_array_ref()).into();
-        let client = self.client().await?;
-        let genesis_hash = *client.genesis_hash();
-        client
+        let genesis_hash = *self.client.genesis_hash();
+        match self
+            .client
             .submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
                 Bytes(
                     CrabChain::sign_transaction(
@@ -134,20 +142,28 @@ impl CrabApi {
                     .encode(),
                 )
             })
-            .await?;
-        Ok(())
+            .await
+        {
+            Ok(_v) => Ok(()),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
     }
 
     /// Update locked collateral
     pub async fn update_locked_collateral(
-        &self,
+        &mut self,
         signer: <CrabChain as TransactionSignScheme>::AccountKeyPair,
         amount: <CrabChain as ChainBase>::Balance,
     ) -> anyhow::Result<()> {
         let signer_id = (*signer.public().as_array_ref()).into();
-        let client = self.client().await?;
-        let genesis_hash = *client.genesis_hash();
-        client
+        let genesis_hash = *self.client.genesis_hash();
+        match self
+            .client
             .submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
                 Bytes(
                     CrabChain::sign_transaction(
@@ -162,7 +178,15 @@ impl CrabApi {
                     .encode(),
                 )
             })
-            .await?;
-        Ok(())
+            .await
+        {
+            Ok(_v) => Ok(()),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
     }
 }

--- a/components/client-crab-s2s/src/api.rs
+++ b/components/client-crab-s2s/src/api.rs
@@ -1,8 +1,8 @@
 use bp_messages::{LaneId, MessageNonce};
 use codec::Encode;
-use common_primitives::AccountId;
-use common_primitives::Balance;
-use common_primitives::BlockNumber;
+use darwinia_common_primitives::AccountId;
+use darwinia_common_primitives::Balance;
+use darwinia_common_primitives::BlockNumber;
 use dp_fee::{Order, Relayer};
 use relay_substrate_client::{ChainBase, Client, TransactionSignScheme, UnsignedTransaction};
 use relay_utils::relay_loop::Client as RelayLoopClient;
@@ -35,7 +35,7 @@ impl CrabApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -57,7 +57,7 @@ impl CrabApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -73,7 +73,7 @@ impl CrabApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -94,7 +94,7 @@ impl CrabApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -106,14 +106,14 @@ impl CrabApi {
     /// Return number of the best finalized block.
     pub async fn best_finalized_header_number(
         &mut self,
-    ) -> anyhow::Result<common_primitives::BlockNumber> {
+    ) -> anyhow::Result<darwinia_common_primitives::BlockNumber> {
         match self.client.best_finalized_header_number().await {
             Ok(v) => Ok(v),
             Err(e) => {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -149,7 +149,7 @@ impl CrabApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -185,7 +185,7 @@ impl CrabApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }

--- a/components/client-crab-s2s/src/api.rs
+++ b/components/client-crab-s2s/src/api.rs
@@ -5,6 +5,7 @@ use common_primitives::Balance;
 use common_primitives::BlockNumber;
 use dp_fee::{Order, Relayer};
 use relay_substrate_client::{ChainBase, Client, TransactionSignScheme, UnsignedTransaction};
+use relay_utils::relay_loop::Client as RelayLoopClient;
 use sp_core::storage::StorageKey;
 use sp_core::{Bytes, Pair};
 
@@ -22,14 +23,17 @@ impl CrabApi {
 }
 
 impl CrabApi {
-    pub async fn client(&self) -> &Client<CrabChain> {
-        &self.client
+    pub async fn client(&self) -> anyhow::Result<Client<CrabChain>> {
+        let mut client = self.client.clone();
+        client.reconnect().await?;
+        Ok(client)
     }
 
     /// Query assigned relayers
     pub async fn assigned_relayers(&self) -> anyhow::Result<Vec<Relayer<AccountId, Balance>>> {
         Ok(self
-            .client
+            .client()
+            .await?
             .storage_value(
                 StorageKey(
                     patch::storage_prefix("FeeMarket".as_bytes(), "AssignedRelayers".as_bytes())
@@ -48,7 +52,8 @@ impl CrabApi {
         message_nonce: MessageNonce,
     ) -> anyhow::Result<Option<Order<AccountId, BlockNumber, Balance>>> {
         Ok(self
-            .client
+            .client()
+            .await?
             .storage_value(
                 bp_runtime::storage_map_final_key_blake2_128concat(
                     "FeeMarket",
@@ -63,7 +68,8 @@ impl CrabApi {
     /// Query all relayers
     pub async fn relayers(&self) -> anyhow::Result<Vec<AccountId>> {
         Ok(self
-            .client
+            .client()
+            .await?
             .storage_value(
                 StorageKey(
                     patch::storage_prefix("FeeMarket".as_bytes(), "Relayers".as_bytes()).to_vec(),
@@ -80,7 +86,8 @@ impl CrabApi {
         account: AccountId,
     ) -> anyhow::Result<Option<Relayer<AccountId, Balance>>> {
         Ok(self
-            .client
+            .client()
+            .await?
             .storage_value(
                 bp_runtime::storage_map_final_key_blake2_128concat(
                     "FeeMarket",
@@ -100,7 +107,7 @@ impl CrabApi {
     pub async fn best_finalized_header_number(
         &self,
     ) -> anyhow::Result<common_primitives::BlockNumber> {
-        Ok(self.client.best_finalized_header_number().await?)
+        Ok(self.client().await?.best_finalized_header_number().await?)
     }
 
     /// Update relay fee
@@ -110,8 +117,9 @@ impl CrabApi {
         amount: <CrabChain as ChainBase>::Balance,
     ) -> anyhow::Result<()> {
         let signer_id = (*signer.public().as_array_ref()).into();
-        let genesis_hash = *self.client.genesis_hash();
-        self.client
+        let client = self.client().await?;
+        let genesis_hash = *client.genesis_hash();
+        client
             .submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
                 Bytes(
                     CrabChain::sign_transaction(
@@ -137,8 +145,9 @@ impl CrabApi {
         amount: <CrabChain as ChainBase>::Balance,
     ) -> anyhow::Result<()> {
         let signer_id = (*signer.public().as_array_ref()).into();
-        let genesis_hash = *self.client.genesis_hash();
-        self.client
+        let client = self.client().await?;
+        let genesis_hash = *client.genesis_hash();
+        client
             .submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
                 Bytes(
                     CrabChain::sign_transaction(

--- a/components/client-crab-s2s/src/crab.rs
+++ b/components/client-crab-s2s/src/crab.rs
@@ -11,7 +11,10 @@ use sp_runtime::{generic::SignedPayload, traits::IdentifyAccount};
 use std::time::Duration;
 
 /// Pangoro header id.
-pub type HeaderId = relay_utils::HeaderId<common_primitives::Hash, common_primitives::BlockNumber>;
+pub type HeaderId = relay_utils::HeaderId<
+    darwinia_common_primitives::Hash,
+    darwinia_common_primitives::BlockNumber,
+>;
 
 /// Pangoro chain definition.
 #[derive(Debug, Clone, Copy)]
@@ -22,23 +25,24 @@ impl BridgeChain for CrabChain {
 }
 
 impl ChainBase for CrabChain {
-    type BlockNumber = common_primitives::BlockNumber;
-    type Hash = common_primitives::Hash;
-    type Hasher = common_primitives::Hashing;
-    type Header = common_primitives::Header;
+    type BlockNumber = darwinia_common_primitives::BlockNumber;
+    type Hash = darwinia_common_primitives::Hash;
+    type Hasher = darwinia_common_primitives::Hashing;
+    type Header = darwinia_common_primitives::Header;
 
-    type AccountId = common_primitives::AccountId;
-    type Balance = common_primitives::Balance;
-    type Index = common_primitives::Nonce;
-    type Signature = common_primitives::Signature;
+    type AccountId = darwinia_common_primitives::AccountId;
+    type Balance = darwinia_common_primitives::Balance;
+    type Index = darwinia_common_primitives::Nonce;
+    type Signature = darwinia_common_primitives::Signature;
 }
 
 impl Chain for CrabChain {
     const NAME: &'static str = "Crab";
     const AVERAGE_BLOCK_INTERVAL: Duration =
-        Duration::from_millis(common_primitives::MILLISECS_PER_BLOCK);
-    const STORAGE_PROOF_OVERHEAD: u32 = bridge_primitives::EXTRA_STORAGE_PROOF_SIZE;
-    const MAXIMAL_ENCODED_ACCOUNT_ID_SIZE: u32 = bridge_primitives::MAXIMAL_ENCODED_ACCOUNT_ID_SIZE;
+        Duration::from_millis(darwinia_common_primitives::MILLISECS_PER_BLOCK);
+    const STORAGE_PROOF_OVERHEAD: u32 = darwinia_bridge_primitives::EXTRA_STORAGE_PROOF_SIZE;
+    const MAXIMAL_ENCODED_ACCOUNT_ID_SIZE: u32 =
+        darwinia_bridge_primitives::MAXIMAL_ENCODED_ACCOUNT_ID_SIZE;
 
     type SignedBlock = crab_runtime::SignedBlock;
     type Call = crab_runtime::Call;
@@ -110,7 +114,7 @@ impl TransactionSignScheme for CrabChain {
         tx.signature
             .as_ref()
             .map(|(address, _, _)| {
-                let account_id: common_primitives::AccountId =
+                let account_id: darwinia_common_primitives::AccountId =
                     (*signer.public().as_array_ref()).into();
                 *address == crab_runtime::Address::from(account_id)
             })
@@ -135,4 +139,4 @@ impl TransactionSignScheme for CrabChain {
 pub type SigningParams = sp_core::sr25519::Pair;
 
 /// Pangoro header type used in headers sync.
-pub type SyncHeader = relay_substrate_client::SyncHeader<common_primitives::Header>;
+pub type SyncHeader = relay_substrate_client::SyncHeader<darwinia_common_primitives::Header>;

--- a/components/client-crab-s2s/src/feemarket.rs
+++ b/components/client-crab-s2s/src/feemarket.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use common_primitives::AccountId;
+use darwinia_common_primitives::AccountId;
 use messages_relay::message_lane::MessageLane;
 use messages_relay::message_lane_loop::{
     SourceClient as MessageLaneSourceClient, TargetClient as MessageLaneTargetClient,
@@ -42,7 +42,7 @@ impl CrabRelayStrategy {
         let nonce = &reference.nonce;
         let order = self
             .api
-            .order(bridge_primitives::DARWINIA_CRAB_LANE, *nonce)
+            .order(darwinia_bridge_primitives::DARWINIA_CRAB_LANE, *nonce)
             .await
             .map_err(|e| {
                 log::error!("[Pangoro] Failed to query order: {:?}", e);
@@ -101,7 +101,7 @@ impl CrabRelayStrategy {
         let ranges = relayers
             .iter()
             .map(|item| item.valid_range.clone())
-            .collect::<Vec<Range<common_primitives::BlockNumber>>>();
+            .collect::<Vec<Range<darwinia_common_primitives::BlockNumber>>>();
 
         let mut maximum_timeout = 0;
         for range in ranges {

--- a/components/client-crab-s2s/src/feemarket.rs
+++ b/components/client-crab-s2s/src/feemarket.rs
@@ -32,7 +32,7 @@ impl CrabRelayStrategy {
         SourceClient: MessageLaneSourceClient<P>,
         TargetClient: MessageLaneTargetClient<P>,
     >(
-        &self,
+        &mut self,
         reference: &mut RelayReference<P, SourceClient, TargetClient>,
     ) -> bool {
         log::trace!(

--- a/components/client-crab-s2s/src/feemarket.rs
+++ b/components/client-crab-s2s/src/feemarket.rs
@@ -126,7 +126,7 @@ impl RelayStrategy for CrabRelayStrategy {
         SourceClient: MessageLaneSourceClient<P>,
         TargetClient: MessageLaneTargetClient<P>,
     >(
-        &self,
+        &mut self,
         reference: &mut RelayReference<P, SourceClient, TargetClient>,
     ) -> bool {
         let decide = self.handle(reference).await;

--- a/components/client-darwinia-s2s/Cargo.toml
+++ b/components/client-darwinia-s2s/Cargo.toml
@@ -33,11 +33,11 @@ bp-messages            = { git = "https://github.com/darwinia-network/parity-bri
 bp-runtime             = { git = "https://github.com/darwinia-network/parity-bridges-common.git", tag = "darwinia-v0.11.6-4" }
 
 ## Bridge dependencies
-darwinia-runtime         = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-common-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-bridge-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-darwinia-bridge-ethereum = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "darwinia-v0.11.6-3" }
-dp-fee                   = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "darwinia-v0.11.6-3" }
+darwinia-runtime           = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+darwinia-common-primitives = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+darwinia-bridge-primitives = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+darwinia-bridge-ethereum   = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps-darwinia" }
+dp-fee                     = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps-darwinia" }
 
 
 

--- a/components/client-darwinia-s2s/Cargo.toml
+++ b/components/client-darwinia-s2s/Cargo.toml
@@ -33,9 +33,9 @@ bp-messages            = { git = "https://github.com/darwinia-network/parity-bri
 bp-runtime             = { git = "https://github.com/darwinia-network/parity-bridges-common.git", tag = "darwinia-v0.11.6-4" }
 
 ## Bridge dependencies
-darwinia-runtime         = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6" }
-common-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6" }
-bridge-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6" }
+darwinia-runtime         = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+common-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+bridge-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
 darwinia-bridge-ethereum = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "darwinia-v0.11.6-3" }
 dp-fee                   = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "darwinia-v0.11.6-3" }
 

--- a/components/client-darwinia-s2s/Cargo.toml
+++ b/components/client-darwinia-s2s/Cargo.toml
@@ -33,11 +33,11 @@ bp-messages            = { git = "https://github.com/darwinia-network/parity-bri
 bp-runtime             = { git = "https://github.com/darwinia-network/parity-bridges-common.git", tag = "darwinia-v0.11.6-4" }
 
 ## Bridge dependencies
-darwinia-runtime           = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-darwinia-common-primitives = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-darwinia-bridge-primitives = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-darwinia-bridge-ethereum   = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps-darwinia" }
-dp-fee                     = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps-darwinia" }
+darwinia-runtime           = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6-bridger" }
+darwinia-common-primitives = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6-bridger" }
+darwinia-bridge-primitives = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6-bridger" }
+darwinia-bridge-ethereum   = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "darwinia-v0.11.6-4" }
+dp-fee                     = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "darwinia-v0.11.6-4" }
 
 
 

--- a/components/client-darwinia-s2s/src/api.rs
+++ b/components/client-darwinia-s2s/src/api.rs
@@ -6,6 +6,7 @@ use common_primitives::BlockNumber;
 use dp_fee::{Order, Relayer};
 use relay_substrate_client::{ChainBase, Client, TransactionSignScheme, UnsignedTransaction};
 use relay_utils::relay_loop::Client as RelayLoopClient;
+use relay_utils::MaybeConnectionError;
 use sp_core::storage::StorageKey;
 use sp_core::{Bytes, Pair};
 
@@ -23,103 +24,110 @@ impl DarwiniaApi {
 }
 
 impl DarwiniaApi {
-    pub async fn client(&self) -> anyhow::Result<Client<DarwiniaChain>> {
-        let mut client = self.client.clone();
-        client.reconnect().await?;
-        Ok(client)
-    }
-
     /// Query assigned relayers
-    pub async fn assigned_relayers(&self) -> anyhow::Result<Vec<Relayer<AccountId, Balance>>> {
-        Ok(self
-            .client()
-            .await?
-            .storage_value(
-                StorageKey(
-                    patch::storage_prefix("FeeMarket".as_bytes(), "AssignedRelayers".as_bytes())
-                        .to_vec(),
-                ),
-                None,
-            )
-            .await?
-            .unwrap_or_else(Vec::new))
-    }
-
-    /// Query all relayers
-    pub async fn relayers(&self) -> anyhow::Result<Vec<AccountId>> {
-        Ok(self
-            .client()
-            .await?
-            .storage_value(
-                StorageKey(
-                    patch::storage_prefix("FeeMarket".as_bytes(), "Relayers".as_bytes()).to_vec(),
-                ),
-                None,
-            )
-            .await?
-            .unwrap_or_else(Vec::new))
-    }
-
-    /// Query relayer info by account id
-    pub async fn relayer(
-        &self,
-        account: AccountId,
-    ) -> anyhow::Result<Option<Relayer<AccountId, Balance>>> {
-        Ok(self
-            .client()
-            .await?
-            .storage_value(
-                bp_runtime::storage_map_final_key_blake2_128concat(
-                    "FeeMarket",
-                    "RelayersMap",
-                    account.encode().as_slice(),
-                ),
-                None,
-            )
-            .await?)
-    }
-
-    pub async fn is_relayer(&self, account: AccountId) -> anyhow::Result<bool> {
-        self.relayer(account).await.map(|item| item.is_some())
+    pub async fn assigned_relayers(&mut self) -> anyhow::Result<Vec<Relayer<AccountId, Balance>>> {
+        let storage_key = StorageKey(
+            patch::storage_prefix("FeeMarket".as_bytes(), "AssignedRelayers".as_bytes()).to_vec(),
+        );
+        match self.client.storage_value(storage_key, None).await {
+            Ok(v) => Ok(v.unwrap_or_default()),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
     }
 
     /// Query order
     pub async fn order(
-        &self,
+        &mut self,
         laned_id: LaneId,
         message_nonce: MessageNonce,
     ) -> anyhow::Result<Option<Order<AccountId, BlockNumber, Balance>>> {
-        Ok(self
-            .client()
-            .await?
-            .storage_value(
-                bp_runtime::storage_map_final_key_blake2_128concat(
-                    "FeeMarket",
-                    "Orders",
-                    (laned_id, message_nonce).encode().as_slice(),
-                ),
-                None,
-            )
-            .await?)
+        let storage_key = bp_runtime::storage_map_final_key_blake2_128concat(
+            "FeeMarket",
+            "Orders",
+            (laned_id, message_nonce).encode().as_slice(),
+        );
+        match self.client.storage_value(storage_key.clone(), None).await {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
+    }
+
+    /// Query all relayers
+    pub async fn relayers(&mut self) -> anyhow::Result<Vec<AccountId>> {
+        let storage_key = StorageKey(
+            patch::storage_prefix("FeeMarket".as_bytes(), "Relayers".as_bytes()).to_vec(),
+        );
+        match self.client.storage_value(storage_key, None).await {
+            Ok(v) => Ok(v.unwrap_or_default()),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
+    }
+
+    /// Query relayer info by account id
+    pub async fn relayer(
+        &mut self,
+        account: AccountId,
+    ) -> anyhow::Result<Option<Relayer<AccountId, Balance>>> {
+        let storage_key = bp_runtime::storage_map_final_key_blake2_128concat(
+            "FeeMarket",
+            "RelayersMap",
+            account.encode().as_slice(),
+        );
+        match self.client.storage_value(storage_key.clone(), None).await {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
+    }
+
+    pub async fn is_relayer(&mut self, account: AccountId) -> anyhow::Result<bool> {
+        self.relayer(account).await.map(|item| item.is_some())
     }
 
     /// Return number of the best finalized block.
     pub async fn best_finalized_header_number(
-        &self,
+        &mut self,
     ) -> anyhow::Result<common_primitives::BlockNumber> {
-        Ok(self.client().await?.best_finalized_header_number().await?)
+        match self.client.best_finalized_header_number().await {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
     }
 
     /// Update relay fee
     pub async fn update_relay_fee(
-        &self,
+        &mut self,
         signer: <DarwiniaChain as TransactionSignScheme>::AccountKeyPair,
         amount: <DarwiniaChain as ChainBase>::Balance,
     ) -> anyhow::Result<()> {
         let signer_id = (*signer.public().as_array_ref()).into();
-        let client = self.client().await?;
-        let genesis_hash = *client.genesis_hash();
-        client
+        let genesis_hash = *self.client.genesis_hash();
+        match self
+            .client
             .submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
                 Bytes(
                     DarwiniaChain::sign_transaction(
@@ -134,20 +142,28 @@ impl DarwiniaApi {
                     .encode(),
                 )
             })
-            .await?;
-        Ok(())
+            .await
+        {
+            Ok(_v) => Ok(()),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
     }
 
     /// Update locked collateral
     pub async fn update_locked_collateral(
-        &self,
+        &mut self,
         signer: <DarwiniaChain as TransactionSignScheme>::AccountKeyPair,
         amount: <DarwiniaChain as ChainBase>::Balance,
     ) -> anyhow::Result<()> {
         let signer_id = (*signer.public().as_array_ref()).into();
-        let client = self.client().await?;
-        let genesis_hash = *client.genesis_hash();
-        client
+        let genesis_hash = *self.client.genesis_hash();
+        match self
+            .client
             .submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
                 Bytes(
                     DarwiniaChain::sign_transaction(
@@ -163,7 +179,15 @@ impl DarwiniaApi {
                     .encode(),
                 )
             })
-            .await?;
-        Ok(())
+            .await
+        {
+            Ok(_v) => Ok(()),
+            Err(e) => {
+                if e.is_connection_error() {
+                    self.client.reconnect().await?;
+                }
+                Err(e)?
+            }
+        }
     }
 }

--- a/components/client-darwinia-s2s/src/api.rs
+++ b/components/client-darwinia-s2s/src/api.rs
@@ -1,8 +1,8 @@
 use bp_messages::{LaneId, MessageNonce};
 use codec::Encode;
-use common_primitives::AccountId;
-use common_primitives::Balance;
-use common_primitives::BlockNumber;
+use darwinia_common_primitives::AccountId;
+use darwinia_common_primitives::Balance;
+use darwinia_common_primitives::BlockNumber;
 use dp_fee::{Order, Relayer};
 use relay_substrate_client::{ChainBase, Client, TransactionSignScheme, UnsignedTransaction};
 use relay_utils::relay_loop::Client as RelayLoopClient;
@@ -35,7 +35,7 @@ impl DarwiniaApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -57,7 +57,7 @@ impl DarwiniaApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -73,7 +73,7 @@ impl DarwiniaApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -94,7 +94,7 @@ impl DarwiniaApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -106,14 +106,14 @@ impl DarwiniaApi {
     /// Return number of the best finalized block.
     pub async fn best_finalized_header_number(
         &mut self,
-    ) -> anyhow::Result<common_primitives::BlockNumber> {
+    ) -> anyhow::Result<darwinia_common_primitives::BlockNumber> {
         match self.client.best_finalized_header_number().await {
             Ok(v) => Ok(v),
             Err(e) => {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -149,7 +149,7 @@ impl DarwiniaApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -186,7 +186,7 @@ impl DarwiniaApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }

--- a/components/client-darwinia-s2s/src/api.rs
+++ b/components/client-darwinia-s2s/src/api.rs
@@ -5,6 +5,7 @@ use common_primitives::Balance;
 use common_primitives::BlockNumber;
 use dp_fee::{Order, Relayer};
 use relay_substrate_client::{ChainBase, Client, TransactionSignScheme, UnsignedTransaction};
+use relay_utils::relay_loop::Client as RelayLoopClient;
 use sp_core::storage::StorageKey;
 use sp_core::{Bytes, Pair};
 
@@ -22,14 +23,17 @@ impl DarwiniaApi {
 }
 
 impl DarwiniaApi {
-    pub async fn client(&self) -> &Client<DarwiniaChain> {
-        &self.client
+    pub async fn client(&self) -> anyhow::Result<Client<DarwiniaChain>> {
+        let mut client = self.client.clone();
+        client.reconnect().await?;
+        Ok(client)
     }
 
     /// Query assigned relayers
     pub async fn assigned_relayers(&self) -> anyhow::Result<Vec<Relayer<AccountId, Balance>>> {
         Ok(self
-            .client
+            .client()
+            .await?
             .storage_value(
                 StorageKey(
                     patch::storage_prefix("FeeMarket".as_bytes(), "AssignedRelayers".as_bytes())
@@ -44,7 +48,8 @@ impl DarwiniaApi {
     /// Query all relayers
     pub async fn relayers(&self) -> anyhow::Result<Vec<AccountId>> {
         Ok(self
-            .client
+            .client()
+            .await?
             .storage_value(
                 StorageKey(
                     patch::storage_prefix("FeeMarket".as_bytes(), "Relayers".as_bytes()).to_vec(),
@@ -61,7 +66,8 @@ impl DarwiniaApi {
         account: AccountId,
     ) -> anyhow::Result<Option<Relayer<AccountId, Balance>>> {
         Ok(self
-            .client
+            .client()
+            .await?
             .storage_value(
                 bp_runtime::storage_map_final_key_blake2_128concat(
                     "FeeMarket",
@@ -84,7 +90,8 @@ impl DarwiniaApi {
         message_nonce: MessageNonce,
     ) -> anyhow::Result<Option<Order<AccountId, BlockNumber, Balance>>> {
         Ok(self
-            .client
+            .client()
+            .await?
             .storage_value(
                 bp_runtime::storage_map_final_key_blake2_128concat(
                     "FeeMarket",
@@ -100,7 +107,7 @@ impl DarwiniaApi {
     pub async fn best_finalized_header_number(
         &self,
     ) -> anyhow::Result<common_primitives::BlockNumber> {
-        Ok(self.client.best_finalized_header_number().await?)
+        Ok(self.client().await?.best_finalized_header_number().await?)
     }
 
     /// Update relay fee
@@ -110,8 +117,9 @@ impl DarwiniaApi {
         amount: <DarwiniaChain as ChainBase>::Balance,
     ) -> anyhow::Result<()> {
         let signer_id = (*signer.public().as_array_ref()).into();
-        let genesis_hash = *self.client.genesis_hash();
-        self.client
+        let client = self.client().await?;
+        let genesis_hash = *client.genesis_hash();
+        client
             .submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
                 Bytes(
                     DarwiniaChain::sign_transaction(
@@ -137,8 +145,9 @@ impl DarwiniaApi {
         amount: <DarwiniaChain as ChainBase>::Balance,
     ) -> anyhow::Result<()> {
         let signer_id = (*signer.public().as_array_ref()).into();
-        let genesis_hash = *self.client.genesis_hash();
-        self.client
+        let client = self.client().await?;
+        let genesis_hash = *client.genesis_hash();
+        client
             .submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
                 Bytes(
                     DarwiniaChain::sign_transaction(

--- a/components/client-darwinia-s2s/src/darwinia.rs
+++ b/components/client-darwinia-s2s/src/darwinia.rs
@@ -10,10 +10,13 @@ use sp_core::{storage::StorageKey, Pair};
 use sp_runtime::{generic::SignedPayload, traits::IdentifyAccount};
 
 /// Pangolin header id.
-pub type HeaderId = relay_utils::HeaderId<common_primitives::Hash, common_primitives::BlockNumber>;
+pub type HeaderId = relay_utils::HeaderId<
+    darwinia_common_primitives::Hash,
+    darwinia_common_primitives::BlockNumber,
+>;
 
 /// Rialto header type used in headers sync.
-pub type SyncHeader = relay_substrate_client::SyncHeader<common_primitives::Header>;
+pub type SyncHeader = relay_substrate_client::SyncHeader<darwinia_common_primitives::Header>;
 
 /// Millau chain definition.
 #[derive(Debug, Clone, Copy)]
@@ -24,23 +27,24 @@ impl BridgeChain for DarwiniaChain {
 }
 
 impl ChainBase for DarwiniaChain {
-    type BlockNumber = common_primitives::BlockNumber;
-    type Hash = common_primitives::Hash;
-    type Hasher = common_primitives::Hashing;
-    type Header = common_primitives::Header;
+    type BlockNumber = darwinia_common_primitives::BlockNumber;
+    type Hash = darwinia_common_primitives::Hash;
+    type Hasher = darwinia_common_primitives::Hashing;
+    type Header = darwinia_common_primitives::Header;
 
-    type AccountId = common_primitives::AccountId;
-    type Balance = common_primitives::Balance;
-    type Index = common_primitives::Nonce;
-    type Signature = common_primitives::Signature;
+    type AccountId = darwinia_common_primitives::AccountId;
+    type Balance = darwinia_common_primitives::Balance;
+    type Index = darwinia_common_primitives::Nonce;
+    type Signature = darwinia_common_primitives::Signature;
 }
 
 impl Chain for DarwiniaChain {
     const NAME: &'static str = "Darwinia";
     const AVERAGE_BLOCK_INTERVAL: Duration =
-        Duration::from_millis(common_primitives::MILLISECS_PER_BLOCK);
-    const STORAGE_PROOF_OVERHEAD: u32 = bridge_primitives::EXTRA_STORAGE_PROOF_SIZE;
-    const MAXIMAL_ENCODED_ACCOUNT_ID_SIZE: u32 = bridge_primitives::MAXIMAL_ENCODED_ACCOUNT_ID_SIZE;
+        Duration::from_millis(darwinia_common_primitives::MILLISECS_PER_BLOCK);
+    const STORAGE_PROOF_OVERHEAD: u32 = darwinia_bridge_primitives::EXTRA_STORAGE_PROOF_SIZE;
+    const MAXIMAL_ENCODED_ACCOUNT_ID_SIZE: u32 =
+        darwinia_bridge_primitives::MAXIMAL_ENCODED_ACCOUNT_ID_SIZE;
 
     type SignedBlock = darwinia_runtime::SignedBlock;
     type Call = darwinia_runtime::Call;
@@ -110,7 +114,7 @@ impl TransactionSignScheme for DarwiniaChain {
         tx.signature
             .as_ref()
             .map(|(address, _, _)| {
-                let account_id: common_primitives::AccountId =
+                let account_id: darwinia_common_primitives::AccountId =
                     (*signer.public().as_array_ref()).into();
                 *address == darwinia_runtime::Address::from(account_id)
             })

--- a/components/client-darwinia-s2s/src/feemarket.rs
+++ b/components/client-darwinia-s2s/src/feemarket.rs
@@ -33,7 +33,7 @@ impl RelayStrategy for DarwiniaRelayStrategy {
         SourceClient: MessageLaneSourceClient<P>,
         TargetClient: MessageLaneTargetClient<P>,
     >(
-        &self,
+        &mut self,
         reference: &mut RelayReference<P, SourceClient, TargetClient>,
     ) -> bool {
         let nonce = &reference.nonce;

--- a/components/client-darwinia-s2s/src/feemarket.rs
+++ b/components/client-darwinia-s2s/src/feemarket.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use common_primitives::AccountId;
+use darwinia_common_primitives::AccountId;
 use messages_relay::message_lane::MessageLane;
 use messages_relay::message_lane_loop::{
     SourceClient as MessageLaneSourceClient, TargetClient as MessageLaneTargetClient,
@@ -39,7 +39,7 @@ impl RelayStrategy for DarwiniaRelayStrategy {
         let nonce = &reference.nonce;
         let order = self
             .api
-            .order(bridge_primitives::DARWINIA_CRAB_LANE, *nonce)
+            .order(darwinia_bridge_primitives::DARWINIA_CRAB_LANE, *nonce)
             .await
             .map_err(|e| {
                 log::error!("Failed to query order: {:?}", e);
@@ -94,7 +94,7 @@ impl RelayStrategy for DarwiniaRelayStrategy {
         let ranges = relayers
             .iter()
             .map(|item| item.valid_range.clone())
-            .collect::<Vec<Range<common_primitives::BlockNumber>>>();
+            .collect::<Vec<Range<darwinia_common_primitives::BlockNumber>>>();
 
         let mut maximum_timeout = 0;
         for range in ranges {

--- a/components/client-pangolin-s2s/Cargo.toml
+++ b/components/client-pangolin-s2s/Cargo.toml
@@ -33,11 +33,11 @@ bp-messages            = { git = "https://github.com/darwinia-network/parity-bri
 bp-runtime             = { git = "https://github.com/darwinia-network/parity-bridges-common.git", tag = "darwinia-v0.11.6-4" }
 
 ## Bridge dependencies
-pangolin-runtime         = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-drml-common-primitives   = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-drml-bridge-primitives   = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-darwinia-bridge-ethereum = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-dp-fee                   = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
+pangolin-runtime         = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
+drml-common-primitives   = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
+drml-bridge-primitives   = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
+darwinia-bridge-ethereum = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
+dp-fee                   = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
 
 
 

--- a/components/client-pangolin-s2s/Cargo.toml
+++ b/components/client-pangolin-s2s/Cargo.toml
@@ -21,6 +21,7 @@ edition = "2018"
 anyhow = "1"
 async-trait = "0.1"
 log = "0.4"
+futures = "0.3"
 
 bridge-traits = { path = "../../traits" }
 

--- a/components/client-pangolin-s2s/Cargo.toml
+++ b/components/client-pangolin-s2s/Cargo.toml
@@ -21,7 +21,6 @@ edition = "2018"
 anyhow = "1"
 async-trait = "0.1"
 log = "0.4"
-futures = "0.3"
 
 bridge-traits = { path = "../../traits" }
 

--- a/components/client-pangolin-s2s/Cargo.toml
+++ b/components/client-pangolin-s2s/Cargo.toml
@@ -34,8 +34,8 @@ bp-runtime             = { git = "https://github.com/darwinia-network/parity-bri
 
 ## Bridge dependencies
 pangolin-runtime         = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-common-primitives        = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-bridge-primitives        = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
+drml-common-primitives   = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
+drml-bridge-primitives   = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
 darwinia-bridge-ethereum = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
 dp-fee                   = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
 

--- a/components/client-pangolin-s2s/src/api.rs
+++ b/components/client-pangolin-s2s/src/api.rs
@@ -5,6 +5,7 @@ use common_primitives::Balance;
 use common_primitives::BlockNumber;
 use dp_fee::{Order, Relayer};
 use relay_substrate_client::{ChainBase, Client, TransactionSignScheme, UnsignedTransaction};
+use relay_utils::relay_loop::Client as RelayLoopClient;
 use sp_core::storage::StorageKey;
 use sp_core::{Bytes, Pair};
 
@@ -22,14 +23,17 @@ impl PangolinApi {
 }
 
 impl PangolinApi {
-    pub async fn client(&self) -> &Client<PangolinChain> {
-        &self.client
+    pub async fn client(&self) -> anyhow::Result<Client<PangolinChain>> {
+        let mut client = self.client.clone();
+        client.reconnect().await?;
+        Ok(client)
     }
 
     /// Query assigned relayers
     pub async fn assigned_relayers(&self) -> anyhow::Result<Vec<Relayer<AccountId, Balance>>> {
         Ok(self
-            .client
+            .client()
+            .await?
             .storage_value(
                 StorageKey(
                     patch::storage_prefix("FeeMarket".as_bytes(), "AssignedRelayers".as_bytes())
@@ -44,7 +48,8 @@ impl PangolinApi {
     /// Query all relayers
     pub async fn relayers(&self) -> anyhow::Result<Vec<AccountId>> {
         Ok(self
-            .client
+            .client()
+            .await?
             .storage_value(
                 StorageKey(
                     patch::storage_prefix("FeeMarket".as_bytes(), "Relayers".as_bytes()).to_vec(),
@@ -61,7 +66,8 @@ impl PangolinApi {
         account: AccountId,
     ) -> anyhow::Result<Option<Relayer<AccountId, Balance>>> {
         Ok(self
-            .client
+            .client()
+            .await?
             .storage_value(
                 bp_runtime::storage_map_final_key_blake2_128concat(
                     "FeeMarket",
@@ -84,7 +90,8 @@ impl PangolinApi {
         message_nonce: MessageNonce,
     ) -> anyhow::Result<Option<Order<AccountId, BlockNumber, Balance>>> {
         Ok(self
-            .client
+            .client()
+            .await?
             .storage_value(
                 bp_runtime::storage_map_final_key_blake2_128concat(
                     "FeeMarket",
@@ -100,7 +107,7 @@ impl PangolinApi {
     pub async fn best_finalized_header_number(
         &self,
     ) -> anyhow::Result<common_primitives::BlockNumber> {
-        Ok(self.client.best_finalized_header_number().await?)
+        Ok(self.client().await?.best_finalized_header_number().await?)
     }
 
     /// Update relay fee
@@ -110,8 +117,9 @@ impl PangolinApi {
         amount: <PangolinChain as ChainBase>::Balance,
     ) -> anyhow::Result<()> {
         let signer_id = (*signer.public().as_array_ref()).into();
-        let genesis_hash = *self.client.genesis_hash();
-        self.client
+        let client = self.client().await?;
+        let genesis_hash = *client.genesis_hash();
+        client
             .submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
                 Bytes(
                     PangolinChain::sign_transaction(
@@ -137,8 +145,9 @@ impl PangolinApi {
         amount: <PangolinChain as ChainBase>::Balance,
     ) -> anyhow::Result<()> {
         let signer_id = (*signer.public().as_array_ref()).into();
-        let genesis_hash = *self.client.genesis_hash();
-        self.client
+        let client = self.client().await?;
+        let genesis_hash = *client.genesis_hash();
+        client
             .submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
                 Bytes(
                     PangolinChain::sign_transaction(

--- a/components/client-pangolin-s2s/src/api.rs
+++ b/components/client-pangolin-s2s/src/api.rs
@@ -1,16 +1,10 @@
-use std::future::Future;
-use std::pin::Pin;
-
 use bp_messages::{LaneId, MessageNonce};
-use bridge_traits::error::StandardError;
-use codec::{Decode, Encode};
-use common_primitives::AccountId;
-use common_primitives::Balance;
-use common_primitives::BlockNumber;
+use codec::Encode;
 use dp_fee::{Order, Relayer};
-use relay_substrate_client::{
-    ChainBase, Client, HeaderIdOf, TransactionSignScheme, UnsignedTransaction,
-};
+use drml_common_primitives::AccountId;
+use drml_common_primitives::Balance;
+use drml_common_primitives::BlockNumber;
+use relay_substrate_client::{ChainBase, Client, TransactionSignScheme, UnsignedTransaction};
 use relay_utils::relay_loop::Client as RelayLoopClient;
 use relay_utils::MaybeConnectionError;
 use sp_core::storage::StorageKey;
@@ -41,7 +35,7 @@ impl PangolinApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -63,7 +57,7 @@ impl PangolinApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -79,7 +73,7 @@ impl PangolinApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -100,7 +94,7 @@ impl PangolinApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -112,14 +106,14 @@ impl PangolinApi {
     /// Return number of the best finalized block.
     pub async fn best_finalized_header_number(
         &mut self,
-    ) -> anyhow::Result<common_primitives::BlockNumber> {
+    ) -> anyhow::Result<drml_common_primitives::BlockNumber> {
         match self.client.best_finalized_header_number().await {
             Ok(v) => Ok(v),
             Err(e) => {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -155,7 +149,7 @@ impl PangolinApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -192,7 +186,7 @@ impl PangolinApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }

--- a/components/client-pangolin-s2s/src/feemarket.rs
+++ b/components/client-pangolin-s2s/src/feemarket.rs
@@ -33,7 +33,7 @@ impl RelayStrategy for PangolinRelayStrategy {
         SourceClient: MessageLaneSourceClient<P>,
         TargetClient: MessageLaneTargetClient<P>,
     >(
-        &self,
+        &mut self,
         reference: &mut RelayReference<P, SourceClient, TargetClient>,
     ) -> bool {
         let nonce = &reference.nonce;

--- a/components/client-pangolin-s2s/src/feemarket.rs
+++ b/components/client-pangolin-s2s/src/feemarket.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use common_primitives::AccountId;
+use drml_common_primitives::AccountId;
 use messages_relay::message_lane::MessageLane;
 use messages_relay::message_lane_loop::{
     SourceClient as MessageLaneSourceClient, TargetClient as MessageLaneTargetClient,
@@ -39,7 +39,7 @@ impl RelayStrategy for PangolinRelayStrategy {
         let nonce = &reference.nonce;
         let order = self
             .api
-            .order(bridge_primitives::PANGORO_PANGOLIN_LANE, *nonce)
+            .order(drml_bridge_primitives::PANGORO_PANGOLIN_LANE, *nonce)
             .await
             .map_err(|e| {
                 log::error!("Failed to query order: {:?}", e);
@@ -94,7 +94,7 @@ impl RelayStrategy for PangolinRelayStrategy {
         let ranges = relayers
             .iter()
             .map(|item| item.valid_range.clone())
-            .collect::<Vec<Range<common_primitives::BlockNumber>>>();
+            .collect::<Vec<Range<drml_common_primitives::BlockNumber>>>();
 
         let mut maximum_timeout = 0;
         for range in ranges {

--- a/components/client-pangolin-s2s/src/pangolin.rs
+++ b/components/client-pangolin-s2s/src/pangolin.rs
@@ -10,10 +10,11 @@ use sp_core::{storage::StorageKey, Pair};
 use sp_runtime::{generic::SignedPayload, traits::IdentifyAccount};
 
 /// Pangolin header id.
-pub type HeaderId = relay_utils::HeaderId<common_primitives::Hash, common_primitives::BlockNumber>;
+pub type HeaderId =
+    relay_utils::HeaderId<drml_common_primitives::Hash, drml_common_primitives::BlockNumber>;
 
 /// Rialto header type used in headers sync.
-pub type SyncHeader = relay_substrate_client::SyncHeader<common_primitives::Header>;
+pub type SyncHeader = relay_substrate_client::SyncHeader<drml_common_primitives::Header>;
 
 /// Millau chain definition.
 #[derive(Debug, Clone, Copy)]
@@ -24,23 +25,24 @@ impl BridgeChain for PangolinChain {
 }
 
 impl ChainBase for PangolinChain {
-    type BlockNumber = common_primitives::BlockNumber;
-    type Hash = common_primitives::Hash;
-    type Hasher = common_primitives::Hashing;
-    type Header = common_primitives::Header;
+    type BlockNumber = drml_common_primitives::BlockNumber;
+    type Hash = drml_common_primitives::Hash;
+    type Hasher = drml_common_primitives::Hashing;
+    type Header = drml_common_primitives::Header;
 
-    type AccountId = common_primitives::AccountId;
-    type Balance = common_primitives::Balance;
-    type Index = common_primitives::Nonce;
-    type Signature = common_primitives::Signature;
+    type AccountId = drml_common_primitives::AccountId;
+    type Balance = drml_common_primitives::Balance;
+    type Index = drml_common_primitives::Nonce;
+    type Signature = drml_common_primitives::Signature;
 }
 
 impl Chain for PangolinChain {
     const NAME: &'static str = "Pangolin";
     const AVERAGE_BLOCK_INTERVAL: Duration =
-        Duration::from_millis(common_primitives::MILLISECS_PER_BLOCK);
-    const STORAGE_PROOF_OVERHEAD: u32 = bridge_primitives::EXTRA_STORAGE_PROOF_SIZE;
-    const MAXIMAL_ENCODED_ACCOUNT_ID_SIZE: u32 = bridge_primitives::MAXIMAL_ENCODED_ACCOUNT_ID_SIZE;
+        Duration::from_millis(drml_common_primitives::MILLISECS_PER_BLOCK);
+    const STORAGE_PROOF_OVERHEAD: u32 = drml_bridge_primitives::EXTRA_STORAGE_PROOF_SIZE;
+    const MAXIMAL_ENCODED_ACCOUNT_ID_SIZE: u32 =
+        drml_bridge_primitives::MAXIMAL_ENCODED_ACCOUNT_ID_SIZE;
 
     type SignedBlock = pangolin_runtime::SignedBlock;
     type Call = pangolin_runtime::Call;
@@ -110,7 +112,7 @@ impl TransactionSignScheme for PangolinChain {
         tx.signature
             .as_ref()
             .map(|(address, _, _)| {
-                let account_id: common_primitives::AccountId =
+                let account_id: drml_common_primitives::AccountId =
                     (*signer.public().as_array_ref()).into();
                 *address == pangolin_runtime::Address::from(account_id)
             })

--- a/components/client-pangolin-s2s/tests/client_substrate.rs
+++ b/components/client-pangolin-s2s/tests/client_substrate.rs
@@ -5,7 +5,7 @@ fn test_account() {
     let signer = "//Alice";
     let pair = sp_core::sr25519::Pair::from_string(&signer, None).unwrap();
     let public = pair.public();
-    let account = common_primitives::AccountId::from(public.0);
+    let account = drml_common_primitives::AccountId::from(public.0);
     assert_eq!(
         account.to_string(),
         "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"

--- a/components/client-pangoro-s2s/Cargo.toml
+++ b/components/client-pangoro-s2s/Cargo.toml
@@ -34,10 +34,10 @@ bp-runtime             = { git = "https://github.com/darwinia-network/parity-bri
 
 
 ## Bridge dependencies
-pangoro-runtime         = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-drml-common-primitives  = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-drml-bridge-primitives  = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-dp-fee                  = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
+pangoro-runtime         = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
+drml-common-primitives  = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
+drml-bridge-primitives  = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
+dp-fee                  = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
 
 
 

--- a/components/client-pangoro-s2s/Cargo.toml
+++ b/components/client-pangoro-s2s/Cargo.toml
@@ -35,8 +35,8 @@ bp-runtime             = { git = "https://github.com/darwinia-network/parity-bri
 
 ## Bridge dependencies
 pangoro-runtime         = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-common-primitives       = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-bridge-primitives       = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
+drml-common-primitives  = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
+drml-bridge-primitives  = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
 dp-fee                  = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
 
 

--- a/components/client-pangoro-s2s/src/api.rs
+++ b/components/client-pangoro-s2s/src/api.rs
@@ -1,9 +1,9 @@
 use bp_messages::{LaneId, MessageNonce};
 use codec::Encode;
-use common_primitives::AccountId;
-use common_primitives::Balance;
-use common_primitives::BlockNumber;
 use dp_fee::{Order, Relayer};
+use drml_common_primitives::AccountId;
+use drml_common_primitives::Balance;
+use drml_common_primitives::BlockNumber;
 use relay_substrate_client::{ChainBase, Client, TransactionSignScheme, UnsignedTransaction};
 use relay_utils::relay_loop::Client as RelayLoopClient;
 use relay_utils::MaybeConnectionError;
@@ -35,7 +35,7 @@ impl PangoroApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -57,7 +57,7 @@ impl PangoroApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -73,7 +73,7 @@ impl PangoroApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -94,7 +94,7 @@ impl PangoroApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -106,14 +106,14 @@ impl PangoroApi {
     /// Return number of the best finalized block.
     pub async fn best_finalized_header_number(
         &mut self,
-    ) -> anyhow::Result<common_primitives::BlockNumber> {
+    ) -> anyhow::Result<drml_common_primitives::BlockNumber> {
         match self.client.best_finalized_header_number().await {
             Ok(v) => Ok(v),
             Err(e) => {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -149,7 +149,7 @@ impl PangoroApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }
@@ -185,7 +185,7 @@ impl PangoroApi {
                 if e.is_connection_error() {
                     self.client.reconnect().await?;
                 }
-                Err(e)?
+                Err(e.into())
             }
         }
     }

--- a/components/client-pangoro-s2s/src/feemarket.rs
+++ b/components/client-pangoro-s2s/src/feemarket.rs
@@ -126,7 +126,7 @@ impl RelayStrategy for PangoroRelayStrategy {
         SourceClient: MessageLaneSourceClient<P>,
         TargetClient: MessageLaneTargetClient<P>,
     >(
-        &self,
+        &mut self,
         reference: &mut RelayReference<P, SourceClient, TargetClient>,
     ) -> bool {
         let decide = self.handle(reference).await;

--- a/components/client-pangoro-s2s/src/feemarket.rs
+++ b/components/client-pangoro-s2s/src/feemarket.rs
@@ -32,7 +32,7 @@ impl PangoroRelayStrategy {
         SourceClient: MessageLaneSourceClient<P>,
         TargetClient: MessageLaneTargetClient<P>,
     >(
-        &self,
+        &mut self,
         reference: &mut RelayReference<P, SourceClient, TargetClient>,
     ) -> bool {
         log::trace!(

--- a/components/client-pangoro-s2s/src/feemarket.rs
+++ b/components/client-pangoro-s2s/src/feemarket.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use common_primitives::AccountId;
+use drml_common_primitives::AccountId;
 use messages_relay::message_lane::MessageLane;
 use messages_relay::message_lane_loop::{
     SourceClient as MessageLaneSourceClient, TargetClient as MessageLaneTargetClient,
@@ -42,7 +42,7 @@ impl PangoroRelayStrategy {
         let nonce = &reference.nonce;
         let order = self
             .api
-            .order(bridge_primitives::PANGORO_PANGOLIN_LANE, *nonce)
+            .order(drml_bridge_primitives::PANGORO_PANGOLIN_LANE, *nonce)
             .await
             .map_err(|e| {
                 log::error!("[Pangoro] Failed to query order: {:?}", e);
@@ -101,7 +101,7 @@ impl PangoroRelayStrategy {
         let ranges = relayers
             .iter()
             .map(|item| item.valid_range.clone())
-            .collect::<Vec<Range<common_primitives::BlockNumber>>>();
+            .collect::<Vec<Range<drml_common_primitives::BlockNumber>>>();
 
         let mut maximum_timeout = 0;
         for range in ranges {

--- a/components/client-pangoro-s2s/src/pangoro.rs
+++ b/components/client-pangoro-s2s/src/pangoro.rs
@@ -11,7 +11,8 @@ use sp_runtime::{generic::SignedPayload, traits::IdentifyAccount};
 use std::time::Duration;
 
 /// Pangoro header id.
-pub type HeaderId = relay_utils::HeaderId<common_primitives::Hash, common_primitives::BlockNumber>;
+pub type HeaderId =
+    relay_utils::HeaderId<drml_common_primitives::Hash, drml_common_primitives::BlockNumber>;
 
 /// Pangoro chain definition.
 #[derive(Debug, Clone, Copy)]
@@ -22,23 +23,24 @@ impl BridgeChain for PangoroChain {
 }
 
 impl ChainBase for PangoroChain {
-    type BlockNumber = common_primitives::BlockNumber;
-    type Hash = common_primitives::Hash;
-    type Hasher = common_primitives::Hashing;
-    type Header = common_primitives::Header;
+    type BlockNumber = drml_common_primitives::BlockNumber;
+    type Hash = drml_common_primitives::Hash;
+    type Hasher = drml_common_primitives::Hashing;
+    type Header = drml_common_primitives::Header;
 
-    type AccountId = common_primitives::AccountId;
-    type Balance = common_primitives::Balance;
-    type Index = common_primitives::Nonce;
-    type Signature = common_primitives::Signature;
+    type AccountId = drml_common_primitives::AccountId;
+    type Balance = drml_common_primitives::Balance;
+    type Index = drml_common_primitives::Nonce;
+    type Signature = drml_common_primitives::Signature;
 }
 
 impl Chain for PangoroChain {
     const NAME: &'static str = "Pangoro";
     const AVERAGE_BLOCK_INTERVAL: Duration =
-        Duration::from_millis(common_primitives::MILLISECS_PER_BLOCK);
-    const STORAGE_PROOF_OVERHEAD: u32 = bridge_primitives::EXTRA_STORAGE_PROOF_SIZE;
-    const MAXIMAL_ENCODED_ACCOUNT_ID_SIZE: u32 = bridge_primitives::MAXIMAL_ENCODED_ACCOUNT_ID_SIZE;
+        Duration::from_millis(drml_common_primitives::MILLISECS_PER_BLOCK);
+    const STORAGE_PROOF_OVERHEAD: u32 = drml_bridge_primitives::EXTRA_STORAGE_PROOF_SIZE;
+    const MAXIMAL_ENCODED_ACCOUNT_ID_SIZE: u32 =
+        drml_bridge_primitives::MAXIMAL_ENCODED_ACCOUNT_ID_SIZE;
 
     type SignedBlock = pangoro_runtime::SignedBlock;
     type Call = pangoro_runtime::Call;
@@ -106,7 +108,7 @@ impl TransactionSignScheme for PangoroChain {
         tx.signature
             .as_ref()
             .map(|(address, _, _)| {
-                let account_id: common_primitives::AccountId =
+                let account_id: drml_common_primitives::AccountId =
                     (*signer.public().as_array_ref()).into();
                 *address == pangoro_runtime::Address::from(account_id)
             })
@@ -131,4 +133,4 @@ impl TransactionSignScheme for PangoroChain {
 pub type SigningParams = sp_core::sr25519::Pair;
 
 /// Pangoro header type used in headers sync.
-pub type SyncHeader = relay_substrate_client::SyncHeader<common_primitives::Header>;
+pub type SyncHeader = relay_substrate_client::SyncHeader<drml_common_primitives::Header>;

--- a/task/task-darwinia-crab/Cargo.toml
+++ b/task/task-darwinia-crab/Cargo.toml
@@ -66,7 +66,7 @@ component-subscan      = { path = "../../components/subscan" }
 ## darwinia common
 bridge-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
 common-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-darwinia-common-runtime  = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+darwinia-runtime-common  = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
 
 ## darwinia
 darwinia-runtime               = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }

--- a/task/task-darwinia-crab/Cargo.toml
+++ b/task/task-darwinia-crab/Cargo.toml
@@ -64,13 +64,13 @@ component-crab-s2s     = { path = "../../components/client-crab-s2s" }
 component-subscan      = { path = "../../components/subscan" }
 
 ## darwinia common
-bridge-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6" }
-common-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6" }
-darwinia-runtime-common  = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6" }
+bridge-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+common-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+darwinia-common-runtime  = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
 
 ## darwinia
-darwinia-runtime               = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6" }
+darwinia-runtime               = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
 
 ## crab
-crab-runtime                   = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6" }
+crab-runtime                   = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
 

--- a/task/task-darwinia-crab/Cargo.toml
+++ b/task/task-darwinia-crab/Cargo.toml
@@ -64,13 +64,13 @@ component-crab-s2s     = { path = "../../components/client-crab-s2s" }
 component-subscan      = { path = "../../components/subscan" }
 
 ## darwinia common
-darwinia-bridge-primitives = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-darwinia-common-primitives = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-darwinia-common-runtime    = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+darwinia-bridge-primitives = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6-bridger" }
+darwinia-common-primitives = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6-bridger" }
+darwinia-common-runtime    = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6-bridger" }
 
 ## darwinia
-darwinia-runtime               = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+darwinia-runtime               = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6-bridger" }
 
 ## crab
-crab-runtime                   = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+crab-runtime                   = { git = "https://github.com/darwinia-network/darwinia.git", tag = "v0.11.6-bridger" }
 

--- a/task/task-darwinia-crab/Cargo.toml
+++ b/task/task-darwinia-crab/Cargo.toml
@@ -64,9 +64,9 @@ component-crab-s2s     = { path = "../../components/client-crab-s2s" }
 component-subscan      = { path = "../../components/subscan" }
 
 ## darwinia common
-bridge-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-common-primitives        = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
-darwinia-runtime-common  = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+darwinia-bridge-primitives = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+darwinia-common-primitives = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
+darwinia-common-runtime    = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }
 
 ## darwinia
 darwinia-runtime               = { git = "https://github.com/darwinia-network/darwinia.git", branch = "bump-deps" }

--- a/task/task-darwinia-crab/src/chains/crab.rs
+++ b/task/task-darwinia-crab/src/chains/crab.rs
@@ -248,9 +248,9 @@ mod s2s_messages {
                 TARGET_NAME,
                 SOURCE_NAME,
                 call_weight,
-                darwinia_common_runtime::max_extrinsic_weight(),
+                darwinia_runtime_common::max_extrinsic_weight(),
                 transaction.encode().len(),
-                darwinia_common_runtime::max_extrinsic_size(),
+                darwinia_runtime_common::max_extrinsic_size(),
             );
             Bytes(transaction.encode())
         }
@@ -298,9 +298,9 @@ mod s2s_messages {
                 SOURCE_NAME,
                 TARGET_NAME,
                 call_weight,
-                darwinia_common_runtime::max_extrinsic_weight(),
+                darwinia_runtime_common::max_extrinsic_weight(),
                 transaction.encode().len(),
-                darwinia_common_runtime::max_extrinsic_size(),
+                darwinia_runtime_common::max_extrinsic_size(),
             );
             Bytes(transaction.encode())
         }
@@ -342,13 +342,13 @@ mod s2s_messages {
 
             // 2/3 is reserved for proofs and tx overhead
             let max_messages_size_in_single_batch =
-                darwinia_common_runtime::max_extrinsic_size() / 3;
+                darwinia_runtime_common::max_extrinsic_size() / 3;
             let (max_messages_in_single_batch, max_messages_weight_in_single_batch) =
                 substrate_relay_helper::messages_lane::select_delivery_transaction_limits::<
                     // todo: there can be change to special weight
                     pallet_bridge_messages::weights::RialtoWeight<crab_runtime::Runtime>,
                 >(
-                    darwinia_common_runtime::max_extrinsic_weight(),
+                    darwinia_runtime_common::max_extrinsic_weight(),
                     DarwiniaChainConst::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE,
                 );
 

--- a/task/task-darwinia-crab/src/chains/crab.rs
+++ b/task/task-darwinia-crab/src/chains/crab.rs
@@ -27,33 +27,33 @@ mod s2s_const {
 
     impl ChainConst for CrabChainConst {
         const OUTBOUND_LANE_MESSAGE_DETAILS_METHOD: &'static str =
-            bridge_primitives::TO_CRAB_MESSAGE_DETAILS_METHOD;
+            darwinia_bridge_primitives::TO_CRAB_MESSAGE_DETAILS_METHOD;
         const OUTBOUND_LANE_LATEST_GENERATED_NONCE_METHOD: &'static str =
-            bridge_primitives::TO_CRAB_LATEST_GENERATED_NONCE_METHOD;
+            darwinia_bridge_primitives::TO_CRAB_LATEST_GENERATED_NONCE_METHOD;
         const OUTBOUND_LANE_LATEST_RECEIVED_NONCE_METHOD: &'static str =
-            bridge_primitives::TO_CRAB_LATEST_RECEIVED_NONCE_METHOD;
+            darwinia_bridge_primitives::TO_CRAB_LATEST_RECEIVED_NONCE_METHOD;
         const INBOUND_LANE_LATEST_RECEIVED_NONCE_METHOD: &'static str =
-            bridge_primitives::FROM_CRAB_LATEST_RECEIVED_NONCE_METHOD;
+            darwinia_bridge_primitives::FROM_CRAB_LATEST_RECEIVED_NONCE_METHOD;
         const INBOUND_LANE_LATEST_CONFIRMED_NONCE_METHOD: &'static str =
-            bridge_primitives::FROM_CRAB_LATEST_CONFIRMED_NONCE_METHOD;
+            darwinia_bridge_primitives::FROM_CRAB_LATEST_CONFIRMED_NONCE_METHOD;
         const INBOUND_LANE_UNREWARDED_RELAYERS_STATE: &'static str =
-            bridge_primitives::FROM_CRAB_UNREWARDED_RELAYERS_STATE;
+            darwinia_bridge_primitives::FROM_CRAB_UNREWARDED_RELAYERS_STATE;
         const BEST_FINALIZED_SOURCE_HEADER_ID_AT_TARGET: &'static str =
-            bridge_primitives::BEST_FINALIZED_CRAB_HEADER_METHOD;
+            darwinia_bridge_primitives::BEST_FINALIZED_CRAB_HEADER_METHOD;
         const BEST_FINALIZED_TARGET_HEADER_ID_AT_SOURCE: &'static str =
-            bridge_primitives::BEST_FINALIZED_CRAB_HEADER_METHOD;
+            darwinia_bridge_primitives::BEST_FINALIZED_CRAB_HEADER_METHOD;
         const MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE: MessageNonce =
-            bridge_primitives::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE;
+            darwinia_bridge_primitives::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE;
         const MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE: MessageNonce =
-            bridge_primitives::MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE;
+            darwinia_bridge_primitives::MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE;
         const AVERAGE_BLOCK_INTERVAL: Duration = DarwiniaChain::AVERAGE_BLOCK_INTERVAL;
-        const BRIDGE_CHAIN_ID: ChainId = bridge_primitives::CRAB_CHAIN_ID;
+        const BRIDGE_CHAIN_ID: ChainId = darwinia_bridge_primitives::CRAB_CHAIN_ID;
         const MESSAGE_PALLET_NAME_AT_SOURCE: &'static str =
-            bridge_primitives::WITH_DARWINIA_MESSAGES_PALLET_NAME;
+            darwinia_bridge_primitives::WITH_DARWINIA_MESSAGES_PALLET_NAME;
         const MESSAGE_PALLET_NAME_AT_TARGET: &'static str =
-            bridge_primitives::WITH_CRAB_MESSAGES_PALLET_NAME;
+            darwinia_bridge_primitives::WITH_CRAB_MESSAGES_PALLET_NAME;
         const PAY_INBOUND_DISPATCH_FEE_WEIGHT_AT_TARGET_CHAIN: Weight =
-            bridge_primitives::PAY_INBOUND_DISPATCH_FEE_WEIGHT;
+            darwinia_bridge_primitives::PAY_INBOUND_DISPATCH_FEE_WEIGHT;
         type SigningParams = sp_core::sr25519::Pair;
     }
 
@@ -111,7 +111,7 @@ mod s2s_headers {
 
         type TargetChain = DarwiniaChain;
 
-        fn transactions_author(&self) -> common_primitives::AccountId {
+        fn transactions_author(&self) -> darwinia_common_primitives::AccountId {
             (*self.finality_pipeline.target_sign.public().as_array_ref()).into()
         }
 
@@ -120,7 +120,7 @@ mod s2s_headers {
             era: bp_runtime::TransactionEraOf<DarwiniaChain>,
             transaction_nonce: IndexOf<DarwiniaChain>,
             header: component_crab_s2s::SyncHeader,
-            proof: GrandpaJustification<common_primitives::Header>,
+            proof: GrandpaJustification<darwinia_common_primitives::Header>,
         ) -> Bytes {
             let call = darwinia_runtime::BridgeGrandpaCall::<
                 darwinia_runtime::Runtime,
@@ -217,7 +217,7 @@ mod s2s_messages {
         type SourceChain = CrabChain;
         type TargetChain = DarwiniaChain;
 
-        fn source_transactions_author(&self) -> common_primitives::AccountId {
+        fn source_transactions_author(&self) -> darwinia_common_primitives::AccountId {
             (*self.message_lane.source_sign.public().as_array_ref()).into()
         }
 
@@ -248,14 +248,14 @@ mod s2s_messages {
                 TARGET_NAME,
                 SOURCE_NAME,
                 call_weight,
-                darwinia_runtime_common::max_extrinsic_weight(),
+                darwinia_common_runtime::max_extrinsic_weight(),
                 transaction.encode().len(),
-                darwinia_runtime_common::max_extrinsic_size(),
+                darwinia_common_runtime::max_extrinsic_size(),
             );
             Bytes(transaction.encode())
         }
 
-        fn target_transactions_author(&self) -> common_primitives::AccountId {
+        fn target_transactions_author(&self) -> darwinia_common_primitives::AccountId {
             (*self.message_lane.target_sign.public().as_array_ref()).into()
         }
 
@@ -298,9 +298,9 @@ mod s2s_messages {
                 SOURCE_NAME,
                 TARGET_NAME,
                 call_weight,
-                darwinia_runtime_common::max_extrinsic_weight(),
+                darwinia_common_runtime::max_extrinsic_weight(),
                 transaction.encode().len(),
-                darwinia_runtime_common::max_extrinsic_size(),
+                darwinia_common_runtime::max_extrinsic_size(),
             );
             Bytes(transaction.encode())
         }
@@ -342,13 +342,13 @@ mod s2s_messages {
 
             // 2/3 is reserved for proofs and tx overhead
             let max_messages_size_in_single_batch =
-                darwinia_runtime_common::max_extrinsic_size() / 3;
+                darwinia_common_runtime::max_extrinsic_size() / 3;
             let (max_messages_in_single_batch, max_messages_weight_in_single_batch) =
                 substrate_relay_helper::messages_lane::select_delivery_transaction_limits::<
                     // todo: there can be change to special weight
                     pallet_bridge_messages::weights::RialtoWeight<crab_runtime::Runtime>,
                 >(
-                    darwinia_runtime_common::max_extrinsic_weight(),
+                    darwinia_common_runtime::max_extrinsic_weight(),
                     DarwiniaChainConst::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE,
                 );
 

--- a/task/task-darwinia-crab/src/chains/crab.rs
+++ b/task/task-darwinia-crab/src/chains/crab.rs
@@ -248,9 +248,9 @@ mod s2s_messages {
                 TARGET_NAME,
                 SOURCE_NAME,
                 call_weight,
-                darwinia_runtime_common::max_extrinsic_weight(),
+                darwinia_common_runtime::max_extrinsic_weight(),
                 transaction.encode().len(),
-                darwinia_runtime_common::max_extrinsic_size(),
+                darwinia_common_runtime::max_extrinsic_size(),
             );
             Bytes(transaction.encode())
         }
@@ -298,9 +298,9 @@ mod s2s_messages {
                 SOURCE_NAME,
                 TARGET_NAME,
                 call_weight,
-                darwinia_runtime_common::max_extrinsic_weight(),
+                darwinia_common_runtime::max_extrinsic_weight(),
                 transaction.encode().len(),
-                darwinia_runtime_common::max_extrinsic_size(),
+                darwinia_common_runtime::max_extrinsic_size(),
             );
             Bytes(transaction.encode())
         }
@@ -342,13 +342,13 @@ mod s2s_messages {
 
             // 2/3 is reserved for proofs and tx overhead
             let max_messages_size_in_single_batch =
-                darwinia_runtime_common::max_extrinsic_size() / 3;
+                darwinia_common_runtime::max_extrinsic_size() / 3;
             let (max_messages_in_single_batch, max_messages_weight_in_single_batch) =
                 substrate_relay_helper::messages_lane::select_delivery_transaction_limits::<
                     // todo: there can be change to special weight
                     pallet_bridge_messages::weights::RialtoWeight<crab_runtime::Runtime>,
                 >(
-                    darwinia_runtime_common::max_extrinsic_weight(),
+                    darwinia_common_runtime::max_extrinsic_weight(),
                     DarwiniaChainConst::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE,
                 );
 

--- a/task/task-darwinia-crab/src/chains/darwinia.rs
+++ b/task/task-darwinia-crab/src/chains/darwinia.rs
@@ -247,9 +247,9 @@ mod s2s_messages {
                 TARGET_NAME,
                 SOURCE_NAME,
                 call_weight,
-                darwinia_common_runtime::max_extrinsic_weight(),
+                darwinia_runtime_common::max_extrinsic_weight(),
                 transaction.encode().len(),
-                darwinia_common_runtime::max_extrinsic_size(),
+                darwinia_runtime_common::max_extrinsic_size(),
             );
             Bytes(transaction.encode())
         }
@@ -297,9 +297,9 @@ mod s2s_messages {
                 SOURCE_NAME,
                 TARGET_NAME,
                 call_weight,
-                darwinia_common_runtime::max_extrinsic_weight(),
+                darwinia_runtime_common::max_extrinsic_weight(),
                 transaction.encode().len(),
-                darwinia_common_runtime::max_extrinsic_size(),
+                darwinia_runtime_common::max_extrinsic_size(),
             );
             Bytes(transaction.encode())
         }
@@ -341,13 +341,13 @@ mod s2s_messages {
 
             // 2/3 is reserved for proofs and tx overhead
             let max_messages_size_in_single_batch =
-                darwinia_common_runtime::max_extrinsic_size() / 3;
+                darwinia_runtime_common::max_extrinsic_size() / 3;
             let (max_messages_in_single_batch, max_messages_weight_in_single_batch) =
                 substrate_relay_helper::messages_lane::select_delivery_transaction_limits::<
                     // todo: there can be change to special weight
                     pallet_bridge_messages::weights::RialtoWeight<darwinia_runtime::Runtime>,
                 >(
-                    darwinia_common_runtime::max_extrinsic_weight(),
+                    darwinia_runtime_common::max_extrinsic_weight(),
                     CrabChainConst::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE,
                 );
 

--- a/task/task-darwinia-crab/src/chains/darwinia.rs
+++ b/task/task-darwinia-crab/src/chains/darwinia.rs
@@ -26,33 +26,33 @@ mod s2s_const {
 
     impl ChainConst for DarwiniaChainConst {
         const OUTBOUND_LANE_MESSAGE_DETAILS_METHOD: &'static str =
-            bridge_primitives::TO_DARWINIA_MESSAGE_DETAILS_METHOD;
+            darwinia_bridge_primitives::TO_DARWINIA_MESSAGE_DETAILS_METHOD;
         const OUTBOUND_LANE_LATEST_GENERATED_NONCE_METHOD: &'static str =
-            bridge_primitives::TO_DARWINIA_LATEST_GENERATED_NONCE_METHOD;
+            darwinia_bridge_primitives::TO_DARWINIA_LATEST_GENERATED_NONCE_METHOD;
         const OUTBOUND_LANE_LATEST_RECEIVED_NONCE_METHOD: &'static str =
-            bridge_primitives::TO_DARWINIA_LATEST_RECEIVED_NONCE_METHOD;
+            darwinia_bridge_primitives::TO_DARWINIA_LATEST_RECEIVED_NONCE_METHOD;
         const INBOUND_LANE_LATEST_RECEIVED_NONCE_METHOD: &'static str =
-            bridge_primitives::FROM_DARWINIA_LATEST_RECEIVED_NONCE_METHOD;
+            darwinia_bridge_primitives::FROM_DARWINIA_LATEST_RECEIVED_NONCE_METHOD;
         const INBOUND_LANE_LATEST_CONFIRMED_NONCE_METHOD: &'static str =
-            bridge_primitives::FROM_DARWINIA_LATEST_CONFIRMED_NONCE_METHOD;
+            darwinia_bridge_primitives::FROM_DARWINIA_LATEST_CONFIRMED_NONCE_METHOD;
         const INBOUND_LANE_UNREWARDED_RELAYERS_STATE: &'static str =
-            bridge_primitives::FROM_DARWINIA_UNREWARDED_RELAYERS_STATE;
+            darwinia_bridge_primitives::FROM_DARWINIA_UNREWARDED_RELAYERS_STATE;
         const BEST_FINALIZED_SOURCE_HEADER_ID_AT_TARGET: &'static str =
-            bridge_primitives::BEST_FINALIZED_DARWINIA_HEADER_METHOD;
+            darwinia_bridge_primitives::BEST_FINALIZED_DARWINIA_HEADER_METHOD;
         const BEST_FINALIZED_TARGET_HEADER_ID_AT_SOURCE: &'static str =
-            bridge_primitives::BEST_FINALIZED_DARWINIA_HEADER_METHOD;
+            darwinia_bridge_primitives::BEST_FINALIZED_DARWINIA_HEADER_METHOD;
         const MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE: MessageNonce =
-            bridge_primitives::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE;
+            darwinia_bridge_primitives::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE;
         const MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE: MessageNonce =
-            bridge_primitives::MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE;
+            darwinia_bridge_primitives::MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE;
         const AVERAGE_BLOCK_INTERVAL: Duration = DarwiniaChain::AVERAGE_BLOCK_INTERVAL;
-        const BRIDGE_CHAIN_ID: ChainId = bridge_primitives::DARWINIA_CHAIN_ID;
+        const BRIDGE_CHAIN_ID: ChainId = darwinia_bridge_primitives::DARWINIA_CHAIN_ID;
         const MESSAGE_PALLET_NAME_AT_SOURCE: &'static str =
-            bridge_primitives::WITH_CRAB_MESSAGES_PALLET_NAME;
+            darwinia_bridge_primitives::WITH_CRAB_MESSAGES_PALLET_NAME;
         const MESSAGE_PALLET_NAME_AT_TARGET: &'static str =
-            bridge_primitives::WITH_DARWINIA_MESSAGES_PALLET_NAME;
+            darwinia_bridge_primitives::WITH_DARWINIA_MESSAGES_PALLET_NAME;
         const PAY_INBOUND_DISPATCH_FEE_WEIGHT_AT_TARGET_CHAIN: Weight =
-            bridge_primitives::PAY_INBOUND_DISPATCH_FEE_WEIGHT;
+            darwinia_bridge_primitives::PAY_INBOUND_DISPATCH_FEE_WEIGHT;
         type SigningParams = sp_core::sr25519::Pair;
     }
 
@@ -110,7 +110,7 @@ mod s2s_headers {
 
         type TargetChain = CrabChain;
 
-        fn transactions_author(&self) -> common_primitives::AccountId {
+        fn transactions_author(&self) -> darwinia_common_primitives::AccountId {
             (*self.finality_pipeline.target_sign.public().as_array_ref()).into()
         }
 
@@ -119,7 +119,7 @@ mod s2s_headers {
             era: bp_runtime::TransactionEraOf<CrabChain>,
             transaction_nonce: IndexOf<CrabChain>,
             header: component_darwinia_s2s::SyncHeader,
-            proof: GrandpaJustification<common_primitives::Header>,
+            proof: GrandpaJustification<darwinia_common_primitives::Header>,
         ) -> Bytes {
             let call = crab_runtime::BridgeGrandpaCall::<
                 crab_runtime::Runtime,
@@ -216,7 +216,7 @@ mod s2s_messages {
         type SourceChain = DarwiniaChain;
         type TargetChain = CrabChain;
 
-        fn source_transactions_author(&self) -> common_primitives::AccountId {
+        fn source_transactions_author(&self) -> darwinia_common_primitives::AccountId {
             (*self.message_lane.source_sign.public().as_array_ref()).into()
         }
 
@@ -247,14 +247,14 @@ mod s2s_messages {
                 TARGET_NAME,
                 SOURCE_NAME,
                 call_weight,
-                darwinia_runtime_common::max_extrinsic_weight(),
+                darwinia_common_runtime::max_extrinsic_weight(),
                 transaction.encode().len(),
-                darwinia_runtime_common::max_extrinsic_size(),
+                darwinia_common_runtime::max_extrinsic_size(),
             );
             Bytes(transaction.encode())
         }
 
-        fn target_transactions_author(&self) -> common_primitives::AccountId {
+        fn target_transactions_author(&self) -> darwinia_common_primitives::AccountId {
             (*self.message_lane.target_sign.public().as_array_ref()).into()
         }
 
@@ -297,9 +297,9 @@ mod s2s_messages {
                 SOURCE_NAME,
                 TARGET_NAME,
                 call_weight,
-                darwinia_runtime_common::max_extrinsic_weight(),
+                darwinia_common_runtime::max_extrinsic_weight(),
                 transaction.encode().len(),
-                darwinia_runtime_common::max_extrinsic_size(),
+                darwinia_common_runtime::max_extrinsic_size(),
             );
             Bytes(transaction.encode())
         }
@@ -341,13 +341,13 @@ mod s2s_messages {
 
             // 2/3 is reserved for proofs and tx overhead
             let max_messages_size_in_single_batch =
-                darwinia_runtime_common::max_extrinsic_size() / 3;
+                darwinia_common_runtime::max_extrinsic_size() / 3;
             let (max_messages_in_single_batch, max_messages_weight_in_single_batch) =
                 substrate_relay_helper::messages_lane::select_delivery_transaction_limits::<
                     // todo: there can be change to special weight
                     pallet_bridge_messages::weights::RialtoWeight<darwinia_runtime::Runtime>,
                 >(
-                    darwinia_runtime_common::max_extrinsic_weight(),
+                    darwinia_common_runtime::max_extrinsic_weight(),
                     CrabChainConst::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE,
                 );
 

--- a/task/task-darwinia-crab/src/chains/darwinia.rs
+++ b/task/task-darwinia-crab/src/chains/darwinia.rs
@@ -247,9 +247,9 @@ mod s2s_messages {
                 TARGET_NAME,
                 SOURCE_NAME,
                 call_weight,
-                darwinia_runtime_common::max_extrinsic_weight(),
+                darwinia_common_runtime::max_extrinsic_weight(),
                 transaction.encode().len(),
-                darwinia_runtime_common::max_extrinsic_size(),
+                darwinia_common_runtime::max_extrinsic_size(),
             );
             Bytes(transaction.encode())
         }
@@ -297,9 +297,9 @@ mod s2s_messages {
                 SOURCE_NAME,
                 TARGET_NAME,
                 call_weight,
-                darwinia_runtime_common::max_extrinsic_weight(),
+                darwinia_common_runtime::max_extrinsic_weight(),
                 transaction.encode().len(),
-                darwinia_runtime_common::max_extrinsic_size(),
+                darwinia_common_runtime::max_extrinsic_size(),
             );
             Bytes(transaction.encode())
         }
@@ -341,13 +341,13 @@ mod s2s_messages {
 
             // 2/3 is reserved for proofs and tx overhead
             let max_messages_size_in_single_batch =
-                darwinia_runtime_common::max_extrinsic_size() / 3;
+                darwinia_common_runtime::max_extrinsic_size() / 3;
             let (max_messages_in_single_batch, max_messages_weight_in_single_batch) =
                 substrate_relay_helper::messages_lane::select_delivery_transaction_limits::<
                     // todo: there can be change to special weight
                     pallet_bridge_messages::weights::RialtoWeight<darwinia_runtime::Runtime>,
                 >(
-                    darwinia_runtime_common::max_extrinsic_weight(),
+                    darwinia_common_runtime::max_extrinsic_weight(),
                     CrabChainConst::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE,
                 );
 

--- a/task/task-darwinia-crab/src/fee/strategy/common.rs
+++ b/task/task-darwinia-crab/src/fee/strategy/common.rs
@@ -49,6 +49,15 @@ impl StrategyHelper {
 }
 
 impl StrategyHelper {
+    pub fn darwinia_api_mut(&mut self) -> &mut DarwiniaApi {
+        &mut self.darwinia_api
+    }
+    pub fn crab_api_mut(&mut self) -> &mut CrabApi {
+        &mut self.crab_api
+    }
+}
+
+impl StrategyHelper {
     pub fn darwinia_api(&self) -> &DarwiniaApi {
         &self.darwinia_api
     }

--- a/task/task-darwinia-crab/src/fee/strategy/common.rs
+++ b/task/task-darwinia-crab/src/fee/strategy/common.rs
@@ -58,12 +58,6 @@ impl StrategyHelper {
 }
 
 impl StrategyHelper {
-    pub fn darwinia_api(&self) -> &DarwiniaApi {
-        &self.darwinia_api
-    }
-    pub fn crab_api(&self) -> &CrabApi {
-        &self.crab_api
-    }
     pub fn darwinia_signer(&self) -> &<DarwiniaChain as TransactionSignScheme>::AccountKeyPair {
         &self.darwinia_signer
     }

--- a/task/task-darwinia-crab/src/fee/strategy/crazy_strategy.rs
+++ b/task/task-darwinia-crab/src/fee/strategy/crazy_strategy.rs
@@ -1,4 +1,4 @@
-use common_primitives::AccountId;
+use darwinia_common_primitives::AccountId;
 use sp_core::Pair;
 
 use bridge_traits::bridge::task::BridgeSand;

--- a/task/task-darwinia-crab/src/fee/strategy/crazy_strategy.rs
+++ b/task/task-darwinia-crab/src/fee/strategy/crazy_strategy.rs
@@ -22,7 +22,7 @@ impl CrazyStrategy {
 
 #[async_trait::async_trait]
 impl UpdateFeeStrategy for CrazyStrategy {
-    async fn handle(&self) -> anyhow::Result<()> {
+    async fn handle(&mut self) -> anyhow::Result<()> {
         self.handle_darwinia().await?;
         self.handle_crab().await?;
         Ok(())
@@ -30,9 +30,11 @@ impl UpdateFeeStrategy for CrazyStrategy {
 }
 
 impl CrazyStrategy {
-    async fn handle_darwinia(&self) -> anyhow::Result<()> {
-        let darwinia_api = self.helper.darwinia_api();
+    async fn handle_darwinia(&mut self) -> anyhow::Result<()> {
         let my_id = AccountId::from(self.helper.darwinia_signer().public().0);
+        let darwinia_signer = self.helper.darwinia_signer().clone();
+
+        let darwinia_api = self.helper.darwinia_api_mut();
 
         if !darwinia_api.is_relayer(my_id.clone()).await? {
             log::warn!(
@@ -64,14 +66,15 @@ impl CrazyStrategy {
             new_fee
         );
         darwinia_api
-            .update_relay_fee(self.helper.darwinia_signer().clone(), new_fee)
+            .update_relay_fee(darwinia_signer, new_fee)
             .await?;
         Ok(())
     }
 
-    async fn handle_crab(&self) -> anyhow::Result<()> {
-        let crab_api = self.helper.crab_api();
+    async fn handle_crab(&mut self) -> anyhow::Result<()> {
         let my_id = AccountId::from(self.helper.crab_signer().public().0);
+        let crab_signer = self.helper.crab_signer().clone();
+        let crab_api = self.helper.crab_api_mut();
 
         if !crab_api.is_relayer(my_id.clone()).await? {
             log::warn!(
@@ -102,9 +105,7 @@ impl CrazyStrategy {
             "[crazy] Update crab fee: {}",
             new_fee
         );
-        crab_api
-            .update_relay_fee(self.helper.crab_signer().clone(), new_fee)
-            .await?;
+        crab_api.update_relay_fee(crab_signer, new_fee).await?;
         Ok(())
     }
 }

--- a/task/task-darwinia-crab/src/fee/strategy/reasonable_strategy.rs
+++ b/task/task-darwinia-crab/src/fee/strategy/reasonable_strategy.rs
@@ -103,7 +103,7 @@ impl ReasonableStrategy {
 
 #[async_trait::async_trait]
 impl UpdateFeeStrategy for ReasonableStrategy {
-    async fn handle(&self) -> anyhow::Result<()> {
+    async fn handle(&mut self) -> anyhow::Result<()> {
         let top100_darwinia = self.subscan_darwinia.extrinsics(1, 100).await?;
         let top100_crab = self.subscan_crab.extrinsics(1, 100).await?;
         let top100_darwinia = top100_darwinia.data()?.ok_or_else(|| {
@@ -142,7 +142,7 @@ impl UpdateFeeStrategy for ReasonableStrategy {
             "[reasonable] Update crab fee: {}",
             expect_fee_crab
         );
-        let crab_api = self.helper.crab_api();
+        let crab_api = self.helper.crab_api_mut();
         crab_api
             .update_relay_fee(self.helper.crab_signer().clone(), expect_fee_crab)
             .await?;
@@ -152,7 +152,7 @@ impl UpdateFeeStrategy for ReasonableStrategy {
             "[reasonable] Update darwinia fee: {}",
             expect_fee_darwinia
         );
-        let darwinia_api = self.helper.darwinia_api();
+        let darwinia_api = self.helper.darwinia_api_mut();
         darwinia_api
             .update_relay_fee(self.helper.darwinia_signer().clone(), expect_fee_darwinia)
             .await?;

--- a/task/task-darwinia-crab/src/fee/strategy/reasonable_strategy.rs
+++ b/task/task-darwinia-crab/src/fee/strategy/reasonable_strategy.rs
@@ -11,8 +11,8 @@ use crate::fee::strategy::common::StrategyHelper;
 use crate::fee::UpdateFeeStrategy;
 use crate::task::DarwiniaCrabTask;
 
-const MIN_RELAY_FEE_DARWINIA: u128 = 15 * common_primitives::COIN;
-const MIN_RELAY_FEE_CRAB: u128 = 15 * common_primitives::COIN;
+const MIN_RELAY_FEE_DARWINIA: u128 = 15 * darwinia_common_primitives::COIN;
+const MIN_RELAY_FEE_CRAB: u128 = 15 * darwinia_common_primitives::COIN;
 
 #[derive(Clone)]
 pub struct ReasonableStrategy {
@@ -79,8 +79,8 @@ impl ReasonableStrategy {
 
     async fn conversion_darwinia_to_crab(
         &self,
-        darwinia_currency: common_primitives::Balance,
-    ) -> anyhow::Result<common_primitives::Balance> {
+        darwinia_currency: darwinia_common_primitives::Balance,
+    ) -> anyhow::Result<darwinia_common_primitives::Balance> {
         let price_darwinia = self._darwinia_open_price().await?;
         let price_crab = self._crab_open_price().await?;
         let rate = price_darwinia / price_crab;
@@ -90,8 +90,8 @@ impl ReasonableStrategy {
     }
     async fn conversion_crab_to_darwinia(
         &self,
-        crab_currency: common_primitives::Balance,
-    ) -> anyhow::Result<common_primitives::Balance> {
+        crab_currency: darwinia_common_primitives::Balance,
+    ) -> anyhow::Result<darwinia_common_primitives::Balance> {
         let price_darwinia = self._darwinia_open_price().await?;
         let price_crab = self._crab_open_price().await?;
         let rate = price_crab / price_darwinia;
@@ -137,6 +137,8 @@ impl UpdateFeeStrategy for ReasonableStrategy {
         let expect_fee_darwinia = MIN_RELAY_FEE_DARWINIA + (top100_max_cost_darwinia * 15);
         let expect_fee_crab = MIN_RELAY_FEE_CRAB + (top100_max_cost_crab * 15);
 
+        let crab_signer = self.helper.crab_signer().clone();
+        let darwinia_signer = self.helper.darwinia_signer().clone();
         log::info!(
             target: DarwiniaCrabTask::NAME,
             "[reasonable] Update crab fee: {}",
@@ -144,7 +146,7 @@ impl UpdateFeeStrategy for ReasonableStrategy {
         );
         let crab_api = self.helper.crab_api_mut();
         crab_api
-            .update_relay_fee(self.helper.crab_signer().clone(), expect_fee_crab)
+            .update_relay_fee(crab_signer, expect_fee_crab)
             .await?;
 
         log::info!(
@@ -154,7 +156,7 @@ impl UpdateFeeStrategy for ReasonableStrategy {
         );
         let darwinia_api = self.helper.darwinia_api_mut();
         darwinia_api
-            .update_relay_fee(self.helper.darwinia_signer().clone(), expect_fee_darwinia)
+            .update_relay_fee(darwinia_signer, expect_fee_darwinia)
             .await?;
         Ok(())
     }

--- a/task/task-darwinia-crab/src/fee/traits.rs
+++ b/task/task-darwinia-crab/src/fee/traits.rs
@@ -1,4 +1,4 @@
 #[async_trait::async_trait]
 pub trait UpdateFeeStrategy {
-    async fn handle(&self) -> anyhow::Result<()>;
+    async fn handle(&mut self) -> anyhow::Result<()>;
 }

--- a/task/task-darwinia-crab/src/service/fee.rs
+++ b/task/task-darwinia-crab/src/service/fee.rs
@@ -74,14 +74,14 @@ async fn run_update_fee(config_task: TaskConfig) -> anyhow::Result<()> {
             if !exists_subscan_config {
                 return Ok(());
             }
-            let strategy = CrazyStrategy::new().await?;
+            let mut strategy = CrazyStrategy::new().await?;
             strategy.handle().await
         }
         UpdateFeeStrategyType::Reasonable => {
             if !exists_subscan_config {
                 return Ok(());
             }
-            let strategy = ReasonableStrategy::new().await?;
+            let mut strategy = ReasonableStrategy::new().await?;
             strategy.handle().await
         }
     }

--- a/task/task-darwinia-crab/src/service/relay.rs
+++ b/task/task-darwinia-crab/src/service/relay.rs
@@ -1,4 +1,4 @@
-use common_primitives::AccountId;
+use darwinia_common_primitives::AccountId;
 use futures::{FutureExt, TryFutureExt};
 use lifeline::{Bus, Lifeline, Receiver, Service, Task};
 use relay_substrate_client::{AccountIdOf, Chain, Client, TransactionSignScheme};
@@ -116,7 +116,7 @@ async fn bridge_relay(relay_info: RelayHeadersAndMessagesInfo) -> anyhow::Result
     if relay_info.create_relayers_fund_accounts {
         let relayer_fund_acount_id = pallet_bridge_messages::relayer_fund_account_id::<
             AccountIdOf<DarwiniaChain>,
-            bridge_primitives::AccountIdConverter,
+            darwinia_bridge_primitives::AccountIdConverter,
         >();
         let relayers_fund_account_balance = darwinia_client
             .free_native_balance(relayer_fund_acount_id.clone())
@@ -135,7 +135,7 @@ async fn bridge_relay(relay_info: RelayHeadersAndMessagesInfo) -> anyhow::Result
 
         let relayer_fund_acount_id = pallet_bridge_messages::relayer_fund_account_id::<
             AccountIdOf<CrabChain>,
-            bridge_primitives::AccountIdConverter,
+            darwinia_bridge_primitives::AccountIdConverter,
         >();
         let relayers_fund_account_balance = crab_client
             .free_native_balance(relayer_fund_acount_id.clone())
@@ -158,7 +158,7 @@ async fn bridge_relay(relay_info: RelayHeadersAndMessagesInfo) -> anyhow::Result
         crab_client.clone(),
         pangoro_transactions_mortality,
         DarwiniaFinalityToCrab::new(crab_client.clone(), pangoro_sign.clone()),
-        common_primitives::DARWINIA_BLOCKS_PER_SESSION,
+        darwinia_common_primitives::DARWINIA_BLOCKS_PER_SESSION,
         relay_info.only_mandatory_headers,
     );
     let crab_to_darwinia_on_demand_headers = OnDemandHeadersRelay::new(
@@ -166,7 +166,7 @@ async fn bridge_relay(relay_info: RelayHeadersAndMessagesInfo) -> anyhow::Result
         darwinia_client.clone(),
         darwinia_transactions_mortality,
         CrabFinalityToDarwinia::new(darwinia_client.clone(), darwinia_sign.clone()),
-        common_primitives::CRAB_BLOCKS_PER_SESSION,
+        darwinia_common_primitives::CRAB_BLOCKS_PER_SESSION,
         relay_info.only_mandatory_headers,
     );
 

--- a/task/task-pangolin-pangoro/Cargo.toml
+++ b/task/task-pangolin-pangoro/Cargo.toml
@@ -64,9 +64,9 @@ component-pangoro-s2s  = { path = "../../components/client-pangoro-s2s" }
 component-subscan      = { path = "../../components/subscan" }
 
 ## darwinia common
-common-primitives   = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-bridge-primitives   = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-common-runtime      = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
+drml-common-primitives  = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
+drml-bridge-primitives  = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
+common-runtime          = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
 
 ## pangolin
 pangolin-runtime               = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }

--- a/task/task-pangolin-pangoro/Cargo.toml
+++ b/task/task-pangolin-pangoro/Cargo.toml
@@ -64,13 +64,13 @@ component-pangoro-s2s  = { path = "../../components/client-pangoro-s2s" }
 component-subscan      = { path = "../../components/subscan" }
 
 ## darwinia common
-drml-common-primitives  = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-drml-bridge-primitives  = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
-common-runtime          = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
+drml-common-primitives  = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
+drml-bridge-primitives  = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
+common-runtime          = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
 
 ## pangolin
-pangolin-runtime               = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
+pangolin-runtime               = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
 
 ## pangoro
-pangoro-runtime                = { git = "https://github.com/darwinia-network/darwinia-common.git", branch = "bump-deps" }
+pangoro-runtime                = { git = "https://github.com/darwinia-network/darwinia-common.git", tag = "v2.7.0-1" }
 

--- a/task/task-pangolin-pangoro/src/chains/pangolin.rs
+++ b/task/task-pangolin-pangoro/src/chains/pangolin.rs
@@ -26,34 +26,34 @@ mod s2s_const {
 
     impl ChainConst for PangolinChainConst {
         const OUTBOUND_LANE_MESSAGE_DETAILS_METHOD: &'static str =
-            bridge_primitives::TO_PANGOLIN_MESSAGE_DETAILS_METHOD;
+            drml_bridge_primitives::TO_PANGOLIN_MESSAGE_DETAILS_METHOD;
         const OUTBOUND_LANE_LATEST_GENERATED_NONCE_METHOD: &'static str =
-            bridge_primitives::TO_PANGOLIN_LATEST_GENERATED_NONCE_METHOD;
+            drml_bridge_primitives::TO_PANGOLIN_LATEST_GENERATED_NONCE_METHOD;
         const OUTBOUND_LANE_LATEST_RECEIVED_NONCE_METHOD: &'static str =
-            bridge_primitives::TO_PANGOLIN_LATEST_RECEIVED_NONCE_METHOD;
+            drml_bridge_primitives::TO_PANGOLIN_LATEST_RECEIVED_NONCE_METHOD;
         const INBOUND_LANE_LATEST_RECEIVED_NONCE_METHOD: &'static str =
-            bridge_primitives::FROM_PANGOLIN_LATEST_RECEIVED_NONCE_METHOD;
+            drml_bridge_primitives::FROM_PANGOLIN_LATEST_RECEIVED_NONCE_METHOD;
         const INBOUND_LANE_LATEST_CONFIRMED_NONCE_METHOD: &'static str =
-            bridge_primitives::FROM_PANGOLIN_LATEST_CONFIRMED_NONCE_METHOD;
+            drml_bridge_primitives::FROM_PANGOLIN_LATEST_CONFIRMED_NONCE_METHOD;
         const INBOUND_LANE_UNREWARDED_RELAYERS_STATE: &'static str =
-            bridge_primitives::FROM_PANGOLIN_UNREWARDED_RELAYERS_STATE;
+            drml_bridge_primitives::FROM_PANGOLIN_UNREWARDED_RELAYERS_STATE;
         const BEST_FINALIZED_SOURCE_HEADER_ID_AT_TARGET: &'static str =
-            bridge_primitives::BEST_FINALIZED_PANGOLIN_HEADER_METHOD;
+            drml_bridge_primitives::BEST_FINALIZED_PANGOLIN_HEADER_METHOD;
         const BEST_FINALIZED_TARGET_HEADER_ID_AT_SOURCE: &'static str =
-            bridge_primitives::BEST_FINALIZED_PANGOLIN_HEADER_METHOD;
+            drml_bridge_primitives::BEST_FINALIZED_PANGOLIN_HEADER_METHOD;
         const MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE: MessageNonce =
-            bridge_primitives::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE;
+            drml_bridge_primitives::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE;
         const MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE: MessageNonce =
-            bridge_primitives::MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE;
+            drml_bridge_primitives::MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE;
         const AVERAGE_BLOCK_INTERVAL: Duration = PangolinChain::AVERAGE_BLOCK_INTERVAL;
-        const BRIDGE_CHAIN_ID: ChainId = bridge_primitives::PANGOLIN_CHAIN_ID;
+        const BRIDGE_CHAIN_ID: ChainId = drml_bridge_primitives::PANGOLIN_CHAIN_ID;
         const MESSAGE_PALLET_NAME_AT_SOURCE: &'static str =
-            bridge_primitives::WITH_PANGORO_MESSAGES_PALLET_NAME;
+            drml_bridge_primitives::WITH_PANGORO_MESSAGES_PALLET_NAME;
         const MESSAGE_PALLET_NAME_AT_TARGET: &'static str =
-            bridge_primitives::WITH_PANGOLIN_MESSAGES_PALLET_NAME;
+            drml_bridge_primitives::WITH_PANGOLIN_MESSAGES_PALLET_NAME;
         const PAY_INBOUND_DISPATCH_FEE_WEIGHT_AT_TARGET_CHAIN: Weight =
-            bridge_primitives::PAY_INBOUND_DISPATCH_FEE_WEIGHT;
-        type SigningParams = common_primitives::SigningParams;
+            drml_bridge_primitives::PAY_INBOUND_DISPATCH_FEE_WEIGHT;
+        type SigningParams = drml_common_primitives::SigningParams;
     }
 
     // === end
@@ -110,7 +110,7 @@ mod s2s_headers {
 
         type TargetChain = PangoroChain;
 
-        fn transactions_author(&self) -> common_primitives::AccountId {
+        fn transactions_author(&self) -> drml_common_primitives::AccountId {
             (*self.finality_pipeline.target_sign.public().as_array_ref()).into()
         }
 
@@ -119,7 +119,7 @@ mod s2s_headers {
             era: bp_runtime::TransactionEraOf<PangoroChain>,
             transaction_nonce: IndexOf<PangoroChain>,
             header: component_pangolin_s2s::SyncHeader,
-            proof: GrandpaJustification<common_primitives::Header>,
+            proof: GrandpaJustification<drml_common_primitives::Header>,
         ) -> Bytes {
             let call = pangoro_runtime::BridgeGrandpaCall::<
                 pangoro_runtime::Runtime,
@@ -216,7 +216,7 @@ mod s2s_messages {
         type SourceChain = PangolinChain;
         type TargetChain = PangoroChain;
 
-        fn source_transactions_author(&self) -> common_primitives::AccountId {
+        fn source_transactions_author(&self) -> drml_common_primitives::AccountId {
             (*self.message_lane.source_sign.public().as_array_ref()).into()
         }
 
@@ -254,7 +254,7 @@ mod s2s_messages {
             Bytes(transaction.encode())
         }
 
-        fn target_transactions_author(&self) -> common_primitives::AccountId {
+        fn target_transactions_author(&self) -> drml_common_primitives::AccountId {
             (*self.message_lane.target_sign.public().as_array_ref()).into()
         }
 

--- a/task/task-pangolin-pangoro/src/chains/pangoro.rs
+++ b/task/task-pangolin-pangoro/src/chains/pangoro.rs
@@ -27,34 +27,34 @@ mod s2s_const {
 
     impl ChainConst for PangoroChainConst {
         const OUTBOUND_LANE_MESSAGE_DETAILS_METHOD: &'static str =
-            bridge_primitives::TO_PANGORO_MESSAGE_DETAILS_METHOD;
+            drml_bridge_primitives::TO_PANGORO_MESSAGE_DETAILS_METHOD;
         const OUTBOUND_LANE_LATEST_GENERATED_NONCE_METHOD: &'static str =
-            bridge_primitives::TO_PANGORO_LATEST_GENERATED_NONCE_METHOD;
+            drml_bridge_primitives::TO_PANGORO_LATEST_GENERATED_NONCE_METHOD;
         const OUTBOUND_LANE_LATEST_RECEIVED_NONCE_METHOD: &'static str =
-            bridge_primitives::TO_PANGORO_LATEST_RECEIVED_NONCE_METHOD;
+            drml_bridge_primitives::TO_PANGORO_LATEST_RECEIVED_NONCE_METHOD;
         const INBOUND_LANE_LATEST_RECEIVED_NONCE_METHOD: &'static str =
-            bridge_primitives::FROM_PANGORO_LATEST_RECEIVED_NONCE_METHOD;
+            drml_bridge_primitives::FROM_PANGORO_LATEST_RECEIVED_NONCE_METHOD;
         const INBOUND_LANE_LATEST_CONFIRMED_NONCE_METHOD: &'static str =
-            bridge_primitives::FROM_PANGORO_LATEST_CONFIRMED_NONCE_METHOD;
+            drml_bridge_primitives::FROM_PANGORO_LATEST_CONFIRMED_NONCE_METHOD;
         const INBOUND_LANE_UNREWARDED_RELAYERS_STATE: &'static str =
-            bridge_primitives::FROM_PANGORO_UNREWARDED_RELAYERS_STATE;
+            drml_bridge_primitives::FROM_PANGORO_UNREWARDED_RELAYERS_STATE;
         const BEST_FINALIZED_SOURCE_HEADER_ID_AT_TARGET: &'static str =
-            bridge_primitives::BEST_FINALIZED_PANGORO_HEADER_METHOD;
+            drml_bridge_primitives::BEST_FINALIZED_PANGORO_HEADER_METHOD;
         const BEST_FINALIZED_TARGET_HEADER_ID_AT_SOURCE: &'static str =
-            bridge_primitives::BEST_FINALIZED_PANGORO_HEADER_METHOD;
+            drml_bridge_primitives::BEST_FINALIZED_PANGORO_HEADER_METHOD;
         const MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE: MessageNonce =
-            bridge_primitives::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE;
+            drml_bridge_primitives::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE;
         const MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE: MessageNonce =
-            bridge_primitives::MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE;
+            drml_bridge_primitives::MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE;
         const AVERAGE_BLOCK_INTERVAL: Duration = PangolinChain::AVERAGE_BLOCK_INTERVAL;
-        const BRIDGE_CHAIN_ID: ChainId = bridge_primitives::PANGORO_CHAIN_ID;
+        const BRIDGE_CHAIN_ID: ChainId = drml_bridge_primitives::PANGORO_CHAIN_ID;
         const MESSAGE_PALLET_NAME_AT_SOURCE: &'static str =
-            bridge_primitives::WITH_PANGOLIN_MESSAGES_PALLET_NAME;
+            drml_bridge_primitives::WITH_PANGOLIN_MESSAGES_PALLET_NAME;
         const MESSAGE_PALLET_NAME_AT_TARGET: &'static str =
-            bridge_primitives::WITH_PANGORO_MESSAGES_PALLET_NAME;
+            drml_bridge_primitives::WITH_PANGORO_MESSAGES_PALLET_NAME;
         const PAY_INBOUND_DISPATCH_FEE_WEIGHT_AT_TARGET_CHAIN: Weight =
-            bridge_primitives::PAY_INBOUND_DISPATCH_FEE_WEIGHT;
-        type SigningParams = common_primitives::SigningParams;
+            drml_bridge_primitives::PAY_INBOUND_DISPATCH_FEE_WEIGHT;
+        type SigningParams = drml_common_primitives::SigningParams;
     }
 
     // === end
@@ -111,7 +111,7 @@ mod s2s_headers {
 
         type TargetChain = PangolinChain;
 
-        fn transactions_author(&self) -> common_primitives::AccountId {
+        fn transactions_author(&self) -> drml_common_primitives::AccountId {
             (*self.finality_pipeline.target_sign.public().as_array_ref()).into()
         }
 
@@ -120,7 +120,7 @@ mod s2s_headers {
             era: bp_runtime::TransactionEraOf<PangolinChain>,
             transaction_nonce: IndexOf<PangolinChain>,
             header: component_pangoro_s2s::SyncHeader,
-            proof: GrandpaJustification<common_primitives::Header>,
+            proof: GrandpaJustification<drml_common_primitives::Header>,
         ) -> Bytes {
             let call = pangolin_runtime::BridgeGrandpaCall::<
                 pangolin_runtime::Runtime,
@@ -217,7 +217,7 @@ mod s2s_messages {
         type SourceChain = PangoroChain;
         type TargetChain = PangolinChain;
 
-        fn source_transactions_author(&self) -> common_primitives::AccountId {
+        fn source_transactions_author(&self) -> drml_common_primitives::AccountId {
             (*self.message_lane.source_sign.public().as_array_ref()).into()
         }
 
@@ -255,7 +255,7 @@ mod s2s_messages {
             Bytes(transaction.encode())
         }
 
-        fn target_transactions_author(&self) -> common_primitives::AccountId {
+        fn target_transactions_author(&self) -> drml_common_primitives::AccountId {
             (*self.message_lane.target_sign.public().as_array_ref()).into()
         }
 

--- a/task/task-pangolin-pangoro/src/fee/strategy/common.rs
+++ b/task/task-pangolin-pangoro/src/fee/strategy/common.rs
@@ -51,6 +51,15 @@ impl StrategyHelper {
 }
 
 impl StrategyHelper {
+    pub fn pangolin_api_mut(&mut self) -> &mut PangolinApi {
+        &mut self.pangolin_api
+    }
+    pub fn pangoro_api_mut(&mut self) -> &mut PangoroApi {
+        &mut self.pangoro_api
+    }
+}
+
+impl StrategyHelper {
     pub fn pangolin_api(&self) -> &PangolinApi {
         &self.pangolin_api
     }

--- a/task/task-pangolin-pangoro/src/fee/strategy/common.rs
+++ b/task/task-pangolin-pangoro/src/fee/strategy/common.rs
@@ -60,12 +60,6 @@ impl StrategyHelper {
 }
 
 impl StrategyHelper {
-    pub fn pangolin_api(&self) -> &PangolinApi {
-        &self.pangolin_api
-    }
-    pub fn pangoro_api(&self) -> &PangoroApi {
-        &self.pangoro_api
-    }
     pub fn pangolin_signer(&self) -> &<PangolinChain as TransactionSignScheme>::AccountKeyPair {
         &self.pangolin_signer
     }

--- a/task/task-pangolin-pangoro/src/fee/strategy/crazy_strategy.rs
+++ b/task/task-pangolin-pangoro/src/fee/strategy/crazy_strategy.rs
@@ -71,8 +71,9 @@ impl CrazyStrategy {
     }
 
     async fn handle_pangoro(&mut self) -> anyhow::Result<()> {
-        let pangoro_api = self.helper.pangoro_api();
         let my_id = AccountId::from(self.helper.pangoro_signer().public().0);
+        let pangoro_signer = self.helper.pangoro_signer().clone();
+        let pangoro_api = self.helper.pangoro_api_mut();
 
         if !pangoro_api.is_relayer(my_id.clone()).await? {
             log::warn!(
@@ -104,7 +105,7 @@ impl CrazyStrategy {
             new_fee
         );
         pangoro_api
-            .update_relay_fee(self.helper.pangoro_signer().clone(), new_fee)
+            .update_relay_fee(pangoro_signer, new_fee)
             .await?;
         Ok(())
     }

--- a/task/task-pangolin-pangoro/src/fee/strategy/crazy_strategy.rs
+++ b/task/task-pangolin-pangoro/src/fee/strategy/crazy_strategy.rs
@@ -22,7 +22,7 @@ impl CrazyStrategy {
 
 #[async_trait::async_trait]
 impl UpdateFeeStrategy for CrazyStrategy {
-    async fn handle(&self) -> anyhow::Result<()> {
+    async fn handle(&mut self) -> anyhow::Result<()> {
         self.handle_pangolin().await?;
         self.handle_pangoro().await?;
         Ok(())
@@ -30,9 +30,10 @@ impl UpdateFeeStrategy for CrazyStrategy {
 }
 
 impl CrazyStrategy {
-    async fn handle_pangolin(&self) -> anyhow::Result<()> {
-        let pangolin_api = self.helper.pangolin_api();
+    async fn handle_pangolin(&mut self) -> anyhow::Result<()> {
         let my_id = AccountId::from(self.helper.pangolin_signer().public().0);
+        let pangolin_signer = self.helper.pangolin_signer().clone();
+        let pangolin_api = self.helper.pangolin_api_mut();
 
         if !pangolin_api.is_relayer(my_id.clone()).await? {
             log::warn!(
@@ -64,12 +65,12 @@ impl CrazyStrategy {
             new_fee
         );
         pangolin_api
-            .update_relay_fee(self.helper.pangolin_signer().clone(), new_fee)
+            .update_relay_fee(pangolin_signer, new_fee)
             .await?;
         Ok(())
     }
 
-    async fn handle_pangoro(&self) -> anyhow::Result<()> {
+    async fn handle_pangoro(&mut self) -> anyhow::Result<()> {
         let pangoro_api = self.helper.pangoro_api();
         let my_id = AccountId::from(self.helper.pangoro_signer().public().0);
 

--- a/task/task-pangolin-pangoro/src/fee/strategy/crazy_strategy.rs
+++ b/task/task-pangolin-pangoro/src/fee/strategy/crazy_strategy.rs
@@ -1,4 +1,4 @@
-use common_primitives::AccountId;
+use drml_common_primitives::AccountId;
 use sp_core::Pair;
 
 use bridge_traits::bridge::task::BridgeSand;

--- a/task/task-pangolin-pangoro/src/fee/strategy/reasonable_strategy.rs
+++ b/task/task-pangolin-pangoro/src/fee/strategy/reasonable_strategy.rs
@@ -145,7 +145,7 @@ impl UpdateFeeStrategy for ReasonableStrategy {
             "[reasonable] Update pangoro fee: {}",
             expect_fee_pangoro
         );
-        let pangoro_api = self.helper.pangoro_api();
+        let pangoro_api = self.helper.pangoro_api_mut();
         pangoro_api
             .update_relay_fee(self.helper.pangoro_signer().clone(), expect_fee_pangoro)
             .await?;
@@ -155,7 +155,7 @@ impl UpdateFeeStrategy for ReasonableStrategy {
             "[reasonable] Update pangolin fee: {}",
             expect_fee_pangolin
         );
-        let pangolin_api = self.helper.pangolin_api();
+        let pangolin_api = self.helper.pangolin_api_mut();
         pangolin_api
             .update_relay_fee(self.helper.pangolin_signer().clone(), expect_fee_pangolin)
             .await?;

--- a/task/task-pangolin-pangoro/src/fee/strategy/reasonable_strategy.rs
+++ b/task/task-pangolin-pangoro/src/fee/strategy/reasonable_strategy.rs
@@ -11,8 +11,8 @@ use crate::fee::strategy::common::StrategyHelper;
 use crate::fee::UpdateFeeStrategy;
 use crate::task::PangolinPangoroTask;
 
-const MIN_RELAY_FEE_PANGOLIN: u128 = 15 * common_primitives::COIN;
-const MIN_RELAY_FEE_PANGORO: u128 = 15 * common_primitives::COIN;
+const MIN_RELAY_FEE_PANGOLIN: u128 = 15 * drml_common_primitives::COIN;
+const MIN_RELAY_FEE_PANGORO: u128 = 15 * drml_common_primitives::COIN;
 
 #[derive(Clone)]
 pub struct ReasonableStrategy {
@@ -80,8 +80,8 @@ impl ReasonableStrategy {
 
     async fn conversion_pangolin_to_pangoro(
         &self,
-        pangolin_currency: common_primitives::Balance,
-    ) -> anyhow::Result<common_primitives::Balance> {
+        pangolin_currency: drml_common_primitives::Balance,
+    ) -> anyhow::Result<drml_common_primitives::Balance> {
         let price_pangolin = self._pangolin_open_price().await?;
         let price_pangoro = self._pangoro_open_price().await?;
         let rate = price_pangolin / price_pangoro;
@@ -91,8 +91,8 @@ impl ReasonableStrategy {
     }
     async fn conversion_pangoro_to_pangolin(
         &self,
-        pangoro_currency: common_primitives::Balance,
-    ) -> anyhow::Result<common_primitives::Balance> {
+        pangoro_currency: drml_common_primitives::Balance,
+    ) -> anyhow::Result<drml_common_primitives::Balance> {
         let price_pangolin = self._pangolin_open_price().await?;
         let price_pangoro = self._pangoro_open_price().await?;
         let rate = price_pangoro / price_pangolin;
@@ -145,9 +145,13 @@ impl UpdateFeeStrategy for ReasonableStrategy {
             "[reasonable] Update pangoro fee: {}",
             expect_fee_pangoro
         );
+
+        let pangoro_signer = self.helper.pangoro_signer().clone();
+        let pangolin_signer = self.helper.pangolin_signer().clone();
+
         let pangoro_api = self.helper.pangoro_api_mut();
         pangoro_api
-            .update_relay_fee(self.helper.pangoro_signer().clone(), expect_fee_pangoro)
+            .update_relay_fee(pangoro_signer, expect_fee_pangoro)
             .await?;
 
         log::info!(
@@ -157,7 +161,7 @@ impl UpdateFeeStrategy for ReasonableStrategy {
         );
         let pangolin_api = self.helper.pangolin_api_mut();
         pangolin_api
-            .update_relay_fee(self.helper.pangolin_signer().clone(), expect_fee_pangolin)
+            .update_relay_fee(pangolin_signer, expect_fee_pangolin)
             .await?;
         Ok(())
     }

--- a/task/task-pangolin-pangoro/src/fee/strategy/reasonable_strategy.rs
+++ b/task/task-pangolin-pangoro/src/fee/strategy/reasonable_strategy.rs
@@ -104,7 +104,7 @@ impl ReasonableStrategy {
 
 #[async_trait::async_trait]
 impl UpdateFeeStrategy for ReasonableStrategy {
-    async fn handle(&self) -> anyhow::Result<()> {
+    async fn handle(&mut self) -> anyhow::Result<()> {
         let top100_pangolin = self.subscan_pangolin.extrinsics(1, 100).await?;
         let top100_pangoro = self.subscan_pangoro.extrinsics(1, 100).await?;
         let top100_pangolin = top100_pangolin.data()?.ok_or_else(|| {

--- a/task/task-pangolin-pangoro/src/fee/traits.rs
+++ b/task/task-pangolin-pangoro/src/fee/traits.rs
@@ -1,4 +1,4 @@
 #[async_trait::async_trait]
 pub trait UpdateFeeStrategy {
-    async fn handle(&self) -> anyhow::Result<()>;
+    async fn handle(&mut self) -> anyhow::Result<()>;
 }

--- a/task/task-pangolin-pangoro/src/service/fee.rs
+++ b/task/task-pangolin-pangoro/src/service/fee.rs
@@ -74,14 +74,14 @@ async fn run_update_fee(config_task: TaskConfig) -> anyhow::Result<()> {
             if !exists_subscan_config {
                 return Ok(());
             }
-            let strategy = CrazyStrategy::new().await?;
+            let mut strategy = CrazyStrategy::new().await?;
             strategy.handle().await
         }
         UpdateFeeStrategyType::Reasonable => {
             if !exists_subscan_config {
                 return Ok(());
             }
-            let strategy = ReasonableStrategy::new().await?;
+            let mut strategy = ReasonableStrategy::new().await?;
             strategy.handle().await
         }
     }

--- a/task/task-pangolin-pangoro/src/service/relay.rs
+++ b/task/task-pangolin-pangoro/src/service/relay.rs
@@ -1,4 +1,4 @@
-use common_primitives::AccountId;
+use drml_common_primitives::AccountId;
 use futures::{FutureExt, TryFutureExt};
 use lifeline::{Bus, Lifeline, Receiver, Service, Task};
 use relay_substrate_client::{AccountIdOf, Chain, Client, TransactionSignScheme};
@@ -137,7 +137,7 @@ async fn bridge_relay(relay_info: RelayHeadersAndMessagesInfo) -> anyhow::Result
     if relay_info.create_relayers_fund_accounts {
         let relayer_fund_acount_id = pallet_bridge_messages::relayer_fund_account_id::<
             AccountIdOf<PangolinChain>,
-            bridge_primitives::AccountIdConverter,
+            drml_bridge_primitives::AccountIdConverter,
         >();
         let relayers_fund_account_balance = pangolin_client
             .free_native_balance(relayer_fund_acount_id.clone())
@@ -156,7 +156,7 @@ async fn bridge_relay(relay_info: RelayHeadersAndMessagesInfo) -> anyhow::Result
 
         let relayer_fund_acount_id = pallet_bridge_messages::relayer_fund_account_id::<
             AccountIdOf<PangoroChain>,
-            bridge_primitives::AccountIdConverter,
+            drml_bridge_primitives::AccountIdConverter,
         >();
         let relayers_fund_account_balance = pangoro_client
             .free_native_balance(relayer_fund_acount_id.clone())
@@ -179,7 +179,7 @@ async fn bridge_relay(relay_info: RelayHeadersAndMessagesInfo) -> anyhow::Result
         pangoro_client.clone(),
         pangoro_transactions_mortality,
         PangolinFinalityToPangoro::new(pangoro_client.clone(), pangoro_sign.clone()),
-        common_primitives::PANGOLIN_BLOCKS_PER_SESSION,
+        drml_common_primitives::PANGOLIN_BLOCKS_PER_SESSION,
         relay_info.only_mandatory_headers,
     );
     let pangoro_to_pangolin_on_demand_headers = OnDemandHeadersRelay::new(
@@ -187,7 +187,7 @@ async fn bridge_relay(relay_info: RelayHeadersAndMessagesInfo) -> anyhow::Result
         pangolin_client.clone(),
         pangolin_transactions_mortality,
         PangoroFinalityToPangolin::new(pangolin_client.clone(), pangolin_sign.clone()),
-        common_primitives::PANGORO_BLOCKS_PER_SESSION,
+        drml_common_primitives::PANGORO_BLOCKS_PER_SESSION,
         relay_info.only_mandatory_headers,
     );
 


### PR DESCRIPTION
Fix connection lost error

```
[2021-11-30T06:13:46Z ERROR component_pangoro_s2s::feemarket] [Pangoro] Failed to query order: The background task been terminated because: Networking or low-level protocol error: WebSocket connection error: 0; restart required

    Caused by:
        The background task been terminated because: Networking or low-level protocol error: WebSocket connection error: 0; restart required

    Stack backtrace:
       0: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
       1: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
       2: messages_relay::message_race_delivery::run::{{closure}}
       3: messages_relay::message_lane_loop::run_until_connection_lost::{{closure}}::{{closure}}::{{closure}}
       4: <futures_util::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
       5: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
       6: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
       7: async_task::raw::RawTask<F,T,S>::run
       8: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
       9: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
      10: async_io::driver::block_on
      11: std::thread::local::LocalKey<T>::with
      12: async_global_executor::threading::thread_main_loop
      13: std::sys_common::backtrace::__rust_begin_short_backtrace
      14: core::ops::function::FnOnce::call_once{{vtable.shim}}
      15: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
                 at ./rustc/db9d361a4731ca0bb48533fab6297a8fea75696f/library/alloc/src/boxed.rs:1694:9
      16: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
                 at ./rustc/db9d361a4731ca0bb48533fab6297a8fea75696f/library/alloc/src/boxed.rs:1694:9
      17: std::sys::unix::thread::Thread::new::thread_start
                 at ./rustc/db9d361a4731ca0bb48533fab6297a8fea75696f/library/std/src/sys/unix/thread.rs:108:17
      18: start_thread
      19: clone
```


~~But now it's not a good solution. because there it's create a new client and reconnect anyway. there is no better solution  currently.~~

~~The reason is [`reconnect`](https://github.com/paritytech/parity-bridges-common/blob/ffef6f89f97936c186e6bdf54c9a76a3d37d69c5/relays/client-substrate/src/client.rs#L86) is a mut function. but the [`RelayStrategy::decide`](https://github.com/darwinia-network/bridger/blob/52475231a448326707c003489fd47659dba48394/components/client-pangolin-s2s/src/feemarket.rs#L31) isn't.~~

Related:
- https://github.com/paritytech/parity-bridges-common/pull/1232
- https://github.com/paritytech/parity-bridges-common/pull/1235



