### PR TITLE
Subquery ci

### DIFF
--- a/.github/workflows/subgraph-dev.yml
+++ b/.github/workflows/subgraph-dev.yml
@@ -22,8 +22,8 @@ jobs:
         working-directory: thegraph
         run: |
           npm i
-          npm run codegen -- subgraph-ropsten.yaml
-          npm run build -- subgraph-ropsten.yaml
+          npm run codegen -- subgraph-${{ matrix.chain }}.yaml
+          npm run build -- subgraph-${{ matrix.chain }}.yaml
           npm run deploy -- --access-token ${{ secrets.THEGRAPH_TOKEN_DEV }} \
             fewensa/bridge-${{ matrix.chain }} \
             subgraph-${{ matrix.chain }}.yaml

--- a/.github/workflows/subgraph-prod.yml
+++ b/.github/workflows/subgraph-prod.yml
@@ -21,8 +21,8 @@ jobs:
         working-directory: thegraph
         run: |
           npm i
-          npm run codegen -- subgraph-ropsten.yaml
-          npm run build -- subgraph-ropsten.yaml
+          npm run codegen -- subgraph-${{ matrix.chain }}.yaml
+          npm run build -- subgraph-${{ matrix.chain }}.yaml
           npm run deploy -- --access-token ${{ secrets.THEGRAPH_TOKEN_PROD }} \
             darwinia-network/bridge-${{ matrix.chain }} \
             subgraph-${{ matrix.chain }}.yaml

--- a/.github/workflows/subquery-dev.yml
+++ b/.github/workflows/subquery-dev.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Deploy
         run: |
+          set -xe
+
           subquery login --token ${{ secrets.SUBQUERY_TOKEN }}
 
           subquery project create \

--- a/.github/workflows/subquery-dev.yml
+++ b/.github/workflows/subquery-dev.yml
@@ -1,8 +1,10 @@
 name: Deploy subquery develop
 
+## IMPORTANT: Please you know, direct push code to master doesn't trigger this action
+#  push:
+#    branches: [ master ]
+
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -42,9 +44,19 @@ jobs:
             --repo https://github.com/darwinia-network/bridger \
             --check
 
-          subquery deployment deploy \
-            --org ${{ env.SUBQUERY_ORG }} \
-            --key subql-bridge-${{ matrix.chain }} \
-            --branch ${{ steps.branch-name.outputs.current_branch }} \
-            --sub-folder subql/${{ matrix.chain }} \
-            --type stage
+          if [ -n "$(git diff ${{ steps.branch-name.outputs.current_branch }} master subql/${{ matrix.chain }}/schema.graphql)" ]; then
+            subquery deployment deploy \
+              --org ${{ env.SUBQUERY_ORG }} \
+              --key subql-bridge-${{ matrix.chain }} \
+              --branch ${{ steps.branch-name.outputs.current_branch }} \
+              --sub-folder subql/${{ matrix.chain }} \
+              --type stage \
+              --force
+          else
+            subquery deployment deploy \
+              --org ${{ env.SUBQUERY_ORG }} \
+              --key subql-bridge-${{ matrix.chain }} \
+              --branch ${{ steps.branch-name.outputs.current_branch }} \
+              --sub-folder subql/${{ matrix.chain }} \
+              --type stage
+          fi

--- a/.github/workflows/subquery-dev.yml
+++ b/.github/workflows/subquery-dev.yml
@@ -34,6 +34,11 @@ jobs:
         id: branch-name
         uses: tj-actions/branch-names@v5.1
 
+      - uses: benjlevesque/short-sha@v1.2
+        id: short-sha
+        with:
+          length: 7
+
       - name: Deploy
         run: |
           set -xe
@@ -46,7 +51,11 @@ jobs:
             --repo https://github.com/darwinia-network/bridger \
             --check
 
-          if [ -n "$(git diff ${{ steps.branch-name.outputs.current_branch }} master subql/${{ matrix.chain }}/schema.graphql)" ]; then
+          DIFF_SCHEMA=$(git diff \
+            ${SHA} \
+            master \
+            subql/${{ matrix.chain }}/schema.graphql || exit 1)
+          if [ -n "${DIFF_SCHEMA}" ]; then
             echo 'Hard deploy subql/${{ matrix.chain }}'
             subquery deployment deploy \
               --org ${{ env.SUBQUERY_ORG }} \

--- a/.github/workflows/subquery-dev.yml
+++ b/.github/workflows/subquery-dev.yml
@@ -55,7 +55,7 @@ jobs:
 
           DIFF_SCHEMA=$(git diff \
             ${SHA} \
-            master \
+            origin/master \
             subql/${{ matrix.chain }}/schema.graphql || exit 1)
           if [ -n "${DIFF_SCHEMA}" ]; then
             echo 'Hard deploy subql/${{ matrix.chain }}'

--- a/.github/workflows/subquery-dev.yml
+++ b/.github/workflows/subquery-dev.yml
@@ -7,8 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  RUST_TOOLCHAIN: stable
-  SUBQUERY_CLI_VERSION: 0.1.4
+  SUBQUERY_CLI_VERSION: 0.1.5
   SUBQUERY_ORG: darwinia-network
 
 jobs:
@@ -21,11 +20,6 @@ jobs:
         chain: [ pangolin, darwinia ]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Install dependencies
         run: |
@@ -53,5 +47,4 @@ jobs:
             --key subql-bridge-${{ matrix.chain }} \
             --branch ${{ steps.branch-name.outputs.current_branch }} \
             --sub-folder subql/${{ matrix.chain }} \
-            --type stage \
-            --force
+            --type stage

--- a/.github/workflows/subquery-dev.yml
+++ b/.github/workflows/subquery-dev.yml
@@ -22,6 +22,8 @@ jobs:
         chain: [ pangolin, darwinia ]
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/subquery-dev.yml
+++ b/.github/workflows/subquery-dev.yml
@@ -45,6 +45,7 @@ jobs:
             --check
 
           if [ -n "$(git diff ${{ steps.branch-name.outputs.current_branch }} master subql/${{ matrix.chain }}/schema.graphql)" ]; then
+            echo 'Hard deploy subql/${{ matrix.chain }}'
             subquery deployment deploy \
               --org ${{ env.SUBQUERY_ORG }} \
               --key subql-bridge-${{ matrix.chain }} \
@@ -53,6 +54,7 @@ jobs:
               --type stage \
               --force
           else
+            echo 'Soft deploy subql/${{ matrix.chain }}'
             subquery deployment deploy \
               --org ${{ env.SUBQUERY_ORG }} \
               --key subql-bridge-${{ matrix.chain }} \

--- a/.github/workflows/subquery-dev.yml
+++ b/.github/workflows/subquery-dev.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/subquery-prod.yml
+++ b/.github/workflows/subquery-prod.yml
@@ -7,8 +7,7 @@ on:
       - 'v*'
 
 env:
-  RUST_TOOLCHAIN: stable
-  SUBQUERY_CLI_VERSION: 0.1.4
+  SUBQUERY_CLI_VERSION: 0.1.5
   SUBQUERY_ORG: darwinia-network
 
 jobs:
@@ -21,11 +20,6 @@ jobs:
         chain: [ pangolin, darwinia ]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Install dependencies
         run: |

--- a/subql/darwinia/schema.graphql
+++ b/subql/darwinia/schema.graphql
@@ -61,3 +61,4 @@ type AuthoritiesChangeSignedEvent @entity {
 
   timestamp: Date
 }
+


### PR DESCRIPTION
Closes #393 

**Develop**

When `subsql/<CHAIN>/schema.graphql` changed, will delete the old stage deployment and create a new stage deployment, this will delete all saved data in Subquery.
If the schema does not changes, just redeploy it. the saved data will keep.

⚠️ ⚠️ ⚠️  Only trigger the in pull request and the base branch is `master`, PLEASE DON'T PUSH CODE TO MASTER BRANCH DIRECTLY.

**Production**

Trigger when creating a new tag.

1. Promote last stage deployment to production deployment.
2. Create a new stage deployment force.

⚠️ ⚠️ ⚠️ Before creating a tag you need to confirm the stage deployment is scan completed.


