### PR TITLE
Custom registry version to support download bridge with custom version

### DIFF
--- a/frame/bin/Cargo.toml
+++ b/frame/bin/Cargo.toml
@@ -40,6 +40,7 @@ serde_with = "1"
 reqwest = { version = "0.11", features = ["blocking", "rustls-tls"] }
 cargo-util = "0.1"
 sys-info = "0.9"
+sysinfo = "0.22"
 zip = "0.5"
 
 microkv = { git = "https://github.com/fewensa/microkv.git", branch = "master" }

--- a/frame/bin/src/command/handler/registry.rs
+++ b/frame/bin/src/command/handler/registry.rs
@@ -34,7 +34,7 @@ fn handle_version(value: Option<String>, bundle: bool) -> color_eyre::Result<()>
             config
                 .registry
                 .version
-                .unwrap_or(bundle_version.to_string()),
+                .unwrap_or_else(|| bundle_version.to_string()),
         );
         return Ok(());
     }

--- a/frame/bin/src/command/handler/registry.rs
+++ b/frame/bin/src/command/handler/registry.rs
@@ -29,7 +29,7 @@ fn handle_version(value: Option<String>, bundle: bool) -> color_eyre::Result<()>
     }
 
     if value.is_none() {
-        let mut config: BridgerConfig = Config::restore(Names::Bridger)?;
+        let config: BridgerConfig = Config::restore(Names::Bridger)?;
         output::output_text(
             config
                 .registry

--- a/frame/bin/src/command/types/registry.rs
+++ b/frame/bin/src/command/types/registry.rs
@@ -34,10 +34,10 @@ pub enum RegistryOpt {
     /// Set registry version, If the value is set, this version of the bridge will be downloaded
     Version {
         /// The version
-        #[structopt(flatten)]
+        #[structopt()]
         value: Option<String>,
         /// Set version to bridger bundle, if true, not use the value parameter
-        #[structopt(flatten)]
+        #[structopt(long)]
         bundle: bool,
     },
 }

--- a/frame/bin/src/command/types/registry.rs
+++ b/frame/bin/src/command/types/registry.rs
@@ -31,4 +31,13 @@ pub enum RegistryOpt {
         #[structopt(short, long, default_value = "raw")]
         output: OutputFormat,
     },
+    /// Set registry version, If the value is set, this version of the bridge will be downloaded
+    Version {
+        /// The version
+        #[structopt(flatten)]
+        value: Option<String>,
+        /// Set version to bridger bundle, if true, not use the value parameter
+        #[structopt(flatten)]
+        bundle: bool,
+    },
 }

--- a/frame/bin/src/config.rs
+++ b/frame/bin/src/config.rs
@@ -19,6 +19,9 @@ pub struct BridgerRegistry {
     /// The path of registry
     #[serde(with = "string_empty_as_none")]
     pub path: Option<String>,
+    /// The version of bridge
+    #[serde(with = "string_empty_as_none")]
+    pub version: Option<String>,
 }
 
 impl Default for BridgerRegistry {
@@ -26,6 +29,7 @@ impl Default for BridgerRegistry {
         Self {
             type_: RegistryType::Github,
             path: Some("https://github.com/darwinia-network/bridger".to_string()),
+            version: None,
         }
     }
 }

--- a/frame/bin/src/external/provider/precompiled_binary.rs
+++ b/frame/bin/src/external/provider/precompiled_binary.rs
@@ -49,7 +49,10 @@ impl PrecompiledBinaryExecutor {
         force: bool,
     ) -> color_eyre::Result<(String, PathBuf)> {
         let config: BridgerConfig = Config::restore(Names::Bridger)?;
-        let version = config.registry.version.unwrap_or(VERSION.to_string());
+        let version = config
+            .registry
+            .version
+            .unwrap_or_else(|| VERSION.to_string());
         for prefix in support_common::constants::ALLOW_BINARY_PREFIX {
             let command = format!("{}{}", prefix, self.command);
 


### PR DESCRIPTION
Closes #394 


Usage
```
bridger registry version                # Show current version
bridger registry version 0.5.1       # Set registry version to 0.5.1
bridger registry version --bundle # Set bundle version to config
```


```
$ ./bridger.sh pangolin-ropsten --version
+ cargo build --manifest-path /dev/bridger/frame/Cargo.toml --package darwinia-bridger
    Finished dev [unoptimized + debuginfo] target(s) in 0.47s
+ /dev/bridger/frame/target/debug/bridger pangolin-ropsten --version
2022-01-11 09:21:47 DEBUG bridger: Found subcommand (pangolin-ropsten) and args: --version
2022-01-11 09:21:47 TRACE bridger: Try execute external command
Try execute bridge-pangolin-ropsten@0.5.0
2022-01-11 09:21:47 TRACE bridger: Force mode: false
2022-01-11 09:21:47 TRACE bridger: Download package path is: /dev/bridger/frame/target/debug/bridge-pangolin-ropsten-windows-x86_64.zip
Downloading `https://github.com/fewensa/bridger/releases/download/v0.5.0/bridge-pangolin-ropsten-windows-x86_64.zip`
2022-01-11 09:21:49 TRACE bridger: Response code is: 200
Downloaded
Start extract /dev/bridger/frame/target/debug/bridge-pangolin-ropsten-windows-x86_64.zip
2022-01-11 09:21:51 DEBUG bridger: File 0 extracted to "/dev/bridger/frame/target/debug/bridge-pangolin-ropsten.exe" (14132224 bytes)
2022-01-11 09:21:52  INFO bridger: Execute `bridge-pangolin-ropsten --version` in path: /dev/bridger/frame/target/debug/
pangolin-ropsten 0.5.0
```


Set custom version

```
$ ./bridger.sh registry version 0.5.1
+ cargo build --manifest-path /dev/bridger/frame/Cargo.toml --package darwinia-bridger
    Finished dev [unoptimized + debuginfo] target(s) in 0.42s
+ /dev/bridger/frame/target/debug/bridger registry version 0.5.1
0.5.1
```




Try download for version 0.5.1
```
$ ./bridger.sh pangolin-ropsten --version
+ cargo build --manifest-path /dev/bridger/frame/Cargo.toml --package darwinia-bridger
    Finished dev [unoptimized + debuginfo] target(s) in 0.41s
+ /dev/bridger/frame/target/debug/bridger pangolin-ropsten --version
2022-01-11 09:22:42 DEBUG bridger: Found subcommand (pangolin-ropsten) and args: --version
2022-01-11 09:22:42 TRACE bridger: Try execute external command
Try execute bridge-pangolin-ropsten@0.5.1
2022-01-11 09:22:42 TRACE bridger: Force mode: false
2022-01-11 09:22:43  WARN bridger: The except version is 0.5.1, but the binary (bridge-pangolin-ropsten) version is: 0.5.0

2022-01-11 09:22:43 TRACE bridger: The version changed, remove old binary for command: bridge-pangolin-ropsten
2022-01-11 09:22:43 TRACE bridger: Download package path is: /dev/bridger/frame/target/debug/bridge-pangolin-ropsten-windows-x86_64.zip
Downloading `https://github.com/fewensa/bridger/releases/download/v0.5.1/bridge-pangolin-ropsten-windows-x86_64.zip`
2022-01-11 09:22:45 TRACE bridger: Response code is: 404
"Custom error: [404] Failed to download package. the url is: https://github.com/fewensa/bridger/releases/download/v0.5.1/bridge-pangolin-ropsten-windows-x86_64.zip"
Try execute bridger-pangolin-ropsten@0.5.1
2022-01-11 09:22:45 TRACE bridger: Force mode: false
2022-01-11 09:22:45 TRACE bridger: Download package path is: /dev/bridger/frame/target/debug/bridger-pangolin-ropsten-windows-x86_64.zip
Downloading `https://github.com/fewensa/bridger/releases/download/v0.5.1/bridger-pangolin-ropsten-windows-x86_64.zip`
2022-01-11 09:22:46 TRACE bridger: Response code is: 404
"Custom error: [404] Failed to download package. the url is: https://github.com/fewensa/bridger/releases/download/v0.5.1/bridger-pangolin-ropsten-windows-x86_64.zip"
error: Found argument 'pangolin-ropsten' which wasn't expected, or isn't valid in this context

USAGE:
    bridger <SUBCOMMAND>

For more information try --help
```


