### PR TITLE
Rename substrate-subxt to subxt

### DIFF
--- a/bridges/darwinia-ethereum/Cargo.lock
+++ b/bridges/darwinia-ethereum/Cargo.lock
@@ -3880,7 +3880,7 @@ dependencies = [
 [[package]]
 name = "substrate-subxt"
 version = "0.15.0"
-source = "git+https://github.com/darwinia-network/substrate-subxt.git?tag=darwinia-v0.11.7#91c613c7ed77ec8e56fd98e27784946c820124b2"
+source = "git+https://github.com/darwinia-network/subxt.git?tag=darwinia-v0.11.7#91c613c7ed77ec8e56fd98e27784946c820124b2"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -3913,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "substrate-subxt-proc-macro"
 version = "0.15.3"
-source = "git+https://github.com/darwinia-network/substrate-subxt.git?tag=darwinia-v0.11.7#91c613c7ed77ec8e56fd98e27784946c820124b2"
+source = "git+https://github.com/darwinia-network/subxt.git?tag=darwinia-v0.11.7#91c613c7ed77ec8e56fd98e27784946c820124b2"
 dependencies = [
  "async-trait",
  "heck",

--- a/bridges/darwinia-ethereum/bridge/Cargo.toml
+++ b/bridges/darwinia-ethereum/bridge/Cargo.toml
@@ -40,7 +40,7 @@ codec       = { package = "parity-scale-codec", version = "2.3.1" }
 web3    = { git = "https://github.com/wuminzhe/rust-web3.git", branch = "master", features = ["signing"] }
 microkv = { git = "https://github.com/fewensa/microkv.git", branch = "master" }
 
-substrate-subxt = { git = "https://github.com/darwinia-network/substrate-subxt.git", tag = "darwinia-v0.11.7" }
+substrate-subxt = { git = "https://github.com/darwinia-network/subxt.git", tag = "darwinia-v0.11.7" }
 
 client-darwinia    = { path = "../client-darwinia" }
 

--- a/bridges/darwinia-ethereum/client-darwinia/Cargo.toml
+++ b/bridges/darwinia-ethereum/client-darwinia/Cargo.toml
@@ -33,8 +33,8 @@ web3      = { git = "https://github.com/wuminzhe/rust-web3.git", branch = "maste
 secp256k1 = { version = "0.20", features = ["recovery"] }
 
 jsonrpsee-types = "0.3"
-substrate-subxt            = { git = "https://github.com/darwinia-network/substrate-subxt.git", tag = "darwinia-v0.11.7" }
-substrate-subxt-proc-macro = { git = "https://github.com/darwinia-network/substrate-subxt.git", tag = "darwinia-v0.11.7" }
+substrate-subxt            = { git = "https://github.com/darwinia-network/subxt.git", tag = "darwinia-v0.11.7" }
+substrate-subxt-proc-macro = { git = "https://github.com/darwinia-network/subxt.git", tag = "darwinia-v0.11.7" }
 
 frame-support    = { git = "https://github.com/darwinia-network/substrate.git", branch = "darwinia-v0.11.7" }
 pallet-indices   = { git = "https://github.com/darwinia-network/substrate.git", branch = "darwinia-v0.11.7" }

--- a/bridges/pangolin-ropsten/Cargo.lock
+++ b/bridges/pangolin-ropsten/Cargo.lock
@@ -3880,7 +3880,7 @@ dependencies = [
 [[package]]
 name = "substrate-subxt"
 version = "0.15.0"
-source = "git+https://github.com/darwinia-network/substrate-subxt.git?tag=darwinia-v0.11.7#91c613c7ed77ec8e56fd98e27784946c820124b2"
+source = "git+https://github.com/darwinia-network/subxt.git?tag=darwinia-v0.11.7#91c613c7ed77ec8e56fd98e27784946c820124b2"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -3913,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "substrate-subxt-proc-macro"
 version = "0.15.3"
-source = "git+https://github.com/darwinia-network/substrate-subxt.git?tag=darwinia-v0.11.7#91c613c7ed77ec8e56fd98e27784946c820124b2"
+source = "git+https://github.com/darwinia-network/subxt.git?tag=darwinia-v0.11.7#91c613c7ed77ec8e56fd98e27784946c820124b2"
 dependencies = [
  "async-trait",
  "heck",

--- a/bridges/pangolin-ropsten/bridge/Cargo.toml
+++ b/bridges/pangolin-ropsten/bridge/Cargo.toml
@@ -40,7 +40,7 @@ codec       = { package = "parity-scale-codec", version = "2.3.1" }
 web3    = { git = "https://github.com/wuminzhe/rust-web3.git", branch = "master", features = ["signing"] }
 microkv = { git = "https://github.com/fewensa/microkv.git", branch = "master" }
 
-substrate-subxt = { git = "https://github.com/darwinia-network/substrate-subxt.git", tag = "darwinia-v0.11.7" }
+substrate-subxt = { git = "https://github.com/darwinia-network/subxt.git", tag = "darwinia-v0.11.7" }
 
 client-pangolin    = { path = "../client-pangolin" }
 

--- a/bridges/pangolin-ropsten/client-pangolin/Cargo.toml
+++ b/bridges/pangolin-ropsten/client-pangolin/Cargo.toml
@@ -33,8 +33,8 @@ web3      = { git = "https://github.com/wuminzhe/rust-web3.git", branch = "maste
 secp256k1 = { version = "0.20", features = ["recovery"] }
 
 jsonrpsee-types = "0.3"
-substrate-subxt            = { git = "https://github.com/darwinia-network/substrate-subxt.git", tag = "darwinia-v0.11.7" }
-substrate-subxt-proc-macro = { git = "https://github.com/darwinia-network/substrate-subxt.git", tag = "darwinia-v0.11.7" }
+substrate-subxt            = { git = "https://github.com/darwinia-network/subxt.git", tag = "darwinia-v0.11.7" }
+substrate-subxt-proc-macro = { git = "https://github.com/darwinia-network/subxt.git", tag = "darwinia-v0.11.7" }
 
 frame-support    = { git = "https://github.com/darwinia-network/substrate.git", branch = "darwinia-v0.11.7" }
 pallet-indices   = { git = "https://github.com/darwinia-network/substrate.git", branch = "darwinia-v0.11.7" }


### PR DESCRIPTION
Following upstream, the substrate-subxt project is renamed to subxt.