### PR TITLE
Defined affirm.relayed types

### DIFF
--- a/frame/supports/support-command-kv/src/schema.toml
+++ b/frame/supports/support-command-kv/src/schema.toml
@@ -8,6 +8,7 @@
   "scan.ropsten.redeem.running" =	"bool"
   "scan.ropsten.affirm.running" =	"bool"
   "affirm.target" = "u64"
+  "affirm.relayed" = "u64"
 
 [darwinia-ethereum]
   "scan.darwinia.planned" = "u64"
@@ -19,3 +20,4 @@
   "scan.ethereum.redeem.running" = "bool"
   "scan.ethereum.affirm.running" = "bool"
   "affirm.target" = "u64"
+  "affirm.relayed" = "u64"


### PR DESCRIPTION
Missing affirm.relayed types

```
2022-03-10 06:17:08 ERROR pangolin-ropsten: [ropsten] [affirm] affirm err: KVError::KVError: invalid type: string "12062166", expected u64 chain="ropsten" action="affirm"
```