### PR TITLE
Fix deploy to subquery

### DIFF
--- a/.github/workflows/subquery-dev.yml
+++ b/.github/workflows/subquery-dev.yml
@@ -9,7 +9,7 @@ on:
     branches: [ master ]
 
 env:
-  SUBQUERY_CLI_VERSION: 0.2.0
+  SUBQUERY_CLI_VERSION: 0.2.3
   SUBQUERY_ORG: darwinia-network
 
 jobs:

--- a/.github/workflows/subquery-prod.yml
+++ b/.github/workflows/subquery-prod.yml
@@ -7,7 +7,7 @@ on:
       - 'v*'
 
 env:
-  SUBQUERY_CLI_VERSION: 0.2.0
+  SUBQUERY_CLI_VERSION: 0.2.3
   SUBQUERY_ORG: darwinia-network
 
 jobs:


### PR DESCRIPTION
https://github.com/darwinia-network/bridger/runs/5549312340?check_suite_focus=true#step:6:38

https://github.com/fewensa/subquery-cli/commit/fe0820720c34774d0d69df9c5692754dcc4407d8


An idea: maybe the subquery cli can be wrapped into action for other repositories to use 
