### PR TITLE
Update header relay strategy

### DIFF
--- a/bridges/pangoro-kiln/bridge/src/kiln_client/client.rs
+++ b/bridges/pangoro-kiln/bridge/src/kiln_client/client.rs
@@ -308,6 +308,7 @@ mod tests {
         println!("Update: {:?}", update);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_get_finality_update() {
         let client = test_client();

--- a/bridges/pangoro-kiln/bridge/src/kiln_client/client.rs
+++ b/bridges/pangoro-kiln/bridge/src/kiln_client/client.rs
@@ -1,6 +1,6 @@
 use super::types::{
-    BlockMessage, Finality, ForkVersion, GetBlockResponse, GetHeaderResponse, Proof,
-    ResponseWrapper, Snapshot, SyncCommitteePeriodUpdate,
+    BlockMessage, Finality, FinalityUpdate, ForkVersion, GetBlockResponse, GetHeaderResponse,
+    Proof, ResponseWrapper, Snapshot, SyncCommitteePeriodUpdate,
 };
 use support_common::error::BridgerError;
 
@@ -217,6 +217,13 @@ impl KilnClient {
         Ok(res.data)
     }
 
+    pub async fn get_finality_update(&self) -> color_eyre::Result<FinalityUpdate> {
+        let url = format!("{}/eth/v1/light_client/finality_update/", self.api_base_url,);
+        let res: ResponseWrapper<FinalityUpdate> =
+            self.api_client.get(url).send().await?.json().await?;
+        Ok(res.data)
+    }
+
     pub async fn get_sync_committee_period_update(
         &self,
         start_period: impl ToString,
@@ -314,5 +321,12 @@ mod tests {
             .await
             .unwrap();
         println!("Update: {:?}", update);
+    }
+
+    #[tokio::test]
+    async fn test_get_finality_update() {
+        let client = test_client();
+        let finality_update = client.get_finality_update().await.unwrap();
+        println!("Finality update: {:?}", finality_update);
     }
 }

--- a/bridges/pangoro-kiln/bridge/src/kiln_client/types.rs
+++ b/bridges/pangoro-kiln/bridge/src/kiln_client/types.rs
@@ -169,3 +169,11 @@ pub struct ForkVersion {
     pub current_version: H32,
     pub epoch: String,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FinalityUpdate {
+    pub attested_header: HeaderMessage,
+    pub finalized_header: HeaderMessage,
+    pub finality_branch: Vec<String>,
+    pub sync_aggregate: SyncAggregate,
+}

--- a/bridges/pangoro-kiln/bridge/src/pangoro_client/client.rs
+++ b/bridges/pangoro-kiln/bridge/src/pangoro_client/client.rs
@@ -75,6 +75,7 @@ impl PangoroClient {
         Ok(query.await?)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn import_finalized_header(
         &self,
         attested_header: &HeaderMessage,

--- a/bridges/pangoro-kiln/bridge/src/pangoro_client/client.rs
+++ b/bridges/pangoro-kiln/bridge/src/pangoro_client/client.rs
@@ -1,13 +1,17 @@
+use crate::{
+    kiln_client::types::{HeaderMessage, SyncAggregate, SyncCommittee},
+    pangoro_client::types::BeaconBlockHeader,
+};
 use secp256k1::SecretKey;
 use std::str::FromStr;
+use support_common::error::BridgerError;
 use web3::{
-    contract::{Contract, Options},
+    contract::{tokens::Tokenize, Contract, Options},
+    ethabi::{ethereum_types::H32, Token},
     transports::Http,
-    types::{Address, H256},
+    types::{Address, H256, U256},
     Web3,
 };
-
-use crate::pangoro_client::types::BeaconBlockHeader;
 
 pub struct PangoroClient {
     pub client: Web3<Http>,
@@ -69,6 +73,54 @@ impl PangoroClient {
             self.execution_layer_contract
                 .query("state_root", (), None, Options::default(), None);
         Ok(query.await?)
+    }
+
+    pub async fn import_finalized_header(
+        &self,
+        attested_header: &HeaderMessage,
+        signature_sync_committee: &SyncCommittee,
+        finalized_header: &HeaderMessage,
+        finality_branch: &[String],
+        sync_aggregate: &SyncAggregate,
+        fork_version: &H32,
+        signature_slot: u64,
+    ) -> color_eyre::Result<H256> {
+        let parameter = Token::Tuple(
+            (
+                attested_header.get_token()?,
+                signature_sync_committee.get_token()?,
+                finalized_header.get_token()?,
+                finality_branch
+                    .iter()
+                    .map(|x| H256::from_str(x))
+                    .collect::<Result<Vec<H256>, _>>()?,
+                sync_aggregate.get_token()?,
+                Token::FixedBytes(fork_version.as_bytes().to_vec()),
+                signature_slot,
+            )
+                .into_tokens(),
+        );
+        let tx = self
+            .contract
+            .signed_call(
+                "import_finalized_header",
+                (parameter,),
+                Options {
+                    gas: Some(U256::from(10000000)),
+                    gas_price: Some(U256::from(1300000000)),
+                    ..Default::default()
+                },
+                &self.private_key.ok_or_else(|| {
+                    BridgerError::Custom("Failed to get log_bloom from block".into())
+                })?,
+            )
+            .await?;
+        tracing::info!(
+            target: "pangoro-kiln",
+            "[Header][Kiln => Pangoro] Sending tx: {:?}",
+            &tx
+        );
+        Ok(tx)
     }
 }
 


### PR DESCRIPTION
Bridger will only relay one header to light client, if there are many periods missed, which implements this strategy: #488 .