### PR TITLE
Disable bridge darwinia-crab for staging ci

### DIFF
--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -21,7 +21,7 @@ jobs:
         package:
           - bridger
 #          - darwinia-ethereum
-          - darwinia-crab
+#          - darwinia-crab
           - pangolin-pangoro
 #          - pangoro-chapel
 #          - pangoro-goerli

--- a/assistants/client-crab/tests/test_component.rs
+++ b/assistants/client-crab/tests/test_component.rs
@@ -31,7 +31,7 @@ async fn test_spec_version() {
     let version = client.subxt().rpc().runtime_version(None).await.unwrap();
     assert_eq!(
         version.other.get("specName"),
-        Some(&serde_json::Value::String("Crab".to_string()))
+        Some(&serde_json::Value::String("Crab2".to_string()))
     );
 }
 


### PR DESCRIPTION
Currently Darwinia not upgrade to 2.0, will be open when bridge fixed