### PR TITLE
On demand header relay

### DIFF
--- a/assistants/bin-e2e/src/bridge.rs
+++ b/assistants/bin-e2e/src/bridge.rs
@@ -1,6 +1,14 @@
 use component_state::state::BridgeState;
 use lifeline::prelude::*;
+use crate::service::header_relay::types::{DarwiniaHeader, EthereumHeader};
 
 lifeline_bus!(pub struct BridgeBus);
 
 impl Resource<BridgeBus> for BridgeState {}
+
+impl Message<BridgeBus> for EthereumHeader {
+    type Channel = tokio::sync::broadcast::Sender<Self>;
+}
+impl Message<BridgeBus> for DarwiniaHeader {
+    type Channel = tokio::sync::broadcast::Sender<Self>;
+}

--- a/assistants/bin-e2e/src/service/header_relay/mod.rs
+++ b/assistants/bin-e2e/src/service/header_relay/mod.rs
@@ -1,2 +1,35 @@
 pub mod beacon_header_relay;
 pub mod sync_committee_relay;
+
+pub mod types {
+    use bridge_e2e_traits::client::OnDemandHeader;
+
+    #[derive(Debug, Clone)]
+    pub struct DarwiniaHeader(pub u64);
+
+    impl From<u64> for DarwiniaHeader {
+        fn from(value: u64) -> Self {
+            Self(value)
+        }
+    }
+
+    impl OnDemandHeader for DarwiniaHeader {
+        fn block_number(&self) -> u64 {
+            self.0
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct EthereumHeader(pub u64);
+    impl From<u64> for EthereumHeader {
+        fn from(value: u64) -> Self {
+            Self(value)
+        }
+    }
+
+    impl OnDemandHeader for EthereumHeader {
+        fn block_number(&self) -> u64 {
+            self.0
+        }
+    }
+}

--- a/assistants/bin-e2e/src/service/message_relay/darwinia_to_eth.rs
+++ b/assistants/bin-e2e/src/service/message_relay/darwinia_to_eth.rs
@@ -6,12 +6,13 @@ use lifeline::dyn_bus::DynBus;
 use relay_e2e::message::darwinia_message_client::DarwiniaMessageClient;
 use relay_e2e::message::ethereum_message_client::EthMessageClient;
 use relay_e2e::message::message_relay_runner::{ChannelState, MessageRelayRunner};
+use tokio::sync::broadcast::Sender;
 use web3::types::{Address, U256};
 
 use crate::bridge::BridgeBus;
 use crate::config::BridgeConfig;
 use crate::service::header_relay::types::{DarwiniaHeader, EthereumHeader};
-use lifeline::{Lifeline, Service, Task};
+use lifeline::{Lifeline, Service, Task, Bus};
 use support_lifeline::service::BridgeService;
 use support_toolkit::timecount::TimeCount;
 
@@ -51,11 +52,13 @@ impl<T: EcdsaClient> Service for DarwiniaEthereumMessageRelay<T> {
             }
             Ok(())
         });
+        let _rx = bus.rx::<EthereumHeader>()?;
+        let tx = bus.tx::<EthereumHeader>()?;
         let _greet_confirmation = Self::try_task(
             "message-confirmation-darwinia-to-eth",
             async move {
                 let mut timecount = TimeCount::new();
-                while let Err(error) = start_confirmation(bridge_config.clone()).await {
+                while let Err(error) = start_confirmation(bridge_config.clone(), tx.clone()).await {
                     tracing::error!(
                         target: "darwinia-eth",
                         "Failed to start darwinia-to-eth message confirmation service, restart after some seconds: {:?}",
@@ -82,12 +85,15 @@ impl<T: EcdsaClient> Service for DarwiniaEthereumMessageRelay<T> {
     }
 }
 
-pub fn message_relay_client_builder<T, O>(
+pub fn message_relay_client_builder<T, O1, O2>(
     config: BridgeConfig<T>,
-) -> color_eyre::Result<MessageRelayRunner<DarwiniaMessageClient, EthMessageClient, O>>
+    delivery_channel_tx: Option<Sender<O1>>,
+    confirm_channel_tx: Option<Sender<O2>>,
+) -> color_eyre::Result<MessageRelayRunner<DarwiniaMessageClient, EthMessageClient, O1, O2>>
 where
     T: EcdsaClient,
-    O: OnDemandHeader,
+    O1: OnDemandHeader,
+    O2: OnDemandHeader,
 {
     let eth_message_client = EthMessageClient::new_with_simple_fee_market(
         "Eth",
@@ -121,12 +127,14 @@ where
         max_message_num_per_relaying: config.general.max_message_num_per_relaying,
         source: darwinia_message_client,
         target: eth_message_client,
-        relay_notifier: None,
+        relay_notifier: delivery_channel_tx,
+        confirm_notifier: confirm_channel_tx,
     })
 }
 
 async fn start_delivery<T: EcdsaClient>(config: BridgeConfig<T>) -> color_eyre::Result<()> {
-    let mut service = message_relay_client_builder::<_, DarwiniaHeader>(config)?;
+    let mut service =
+        message_relay_client_builder::<_, DarwiniaHeader, EthereumHeader>(config, None, None)?;
     loop {
         if let Err(error) = service.message_relay().await {
             tracing::error!(
@@ -140,8 +148,15 @@ async fn start_delivery<T: EcdsaClient>(config: BridgeConfig<T>) -> color_eyre::
     }
 }
 
-async fn start_confirmation<T: EcdsaClient>(config: BridgeConfig<T>) -> color_eyre::Result<()> {
-    let mut service = message_relay_client_builder::<_, EthereumHeader>(config)?;
+async fn start_confirmation<T: EcdsaClient>(
+    config: BridgeConfig<T>,
+    confirm_channel_tx: Sender<EthereumHeader>,
+) -> color_eyre::Result<()> {
+    let mut service = message_relay_client_builder::<_, DarwiniaHeader, EthereumHeader>(
+        config,
+        None,
+        Some(confirm_channel_tx),
+    )?;
     loop {
         if let Err(error) = service.message_confirm().await {
             tracing::error!(

--- a/assistants/client-contracts/src/beacon_light_client.rs
+++ b/assistants/client-contracts/src/beacon_light_client.rs
@@ -4,7 +4,7 @@ use web3::{
     contract::{tokens::Tokenize, Contract, Options},
     signing::Key,
     transports::Http,
-    types::{Address, H256, BlockId},
+    types::{Address, H256, BlockId, U256},
     Web3,
 };
 
@@ -58,6 +58,13 @@ impl BeaconLightClient {
         Ok(self
             .contract
             .query("merkle_root", (), None, Options::default(), at_block)
+            .await?)
+    }
+
+    pub async fn block_number(&self) -> BridgeContractResult<U256> {
+        Ok(self
+            .contract
+            .query("block_number", (), None, Options::default(), None)
             .await?)
     }
 

--- a/assistants/relay-e2e/src/header/eth_beacon_header_relay.rs
+++ b/assistants/relay-e2e/src/header/eth_beacon_header_relay.rs
@@ -4,10 +4,11 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use bridge_e2e_traits::client::EthTruthLayerLightClient;
+use bridge_e2e_traits::client::{EthTruthLayerLightClient, OnDemandHeader};
 use client_beacon::{client::BeaconApiClient, types::FinalityUpdate};
 use client_contracts::beacon_light_client_types::FinalizedHeaderUpdate;
 use support_etherscan::wait_for_transaction_confirmation_with_timeout;
+use tokio::sync::broadcast::Receiver;
 use web3::{
     contract::Options,
     types::{Bytes, H256},
@@ -15,9 +16,14 @@ use web3::{
 
 use crate::error::{RelayError, RelayResult};
 
-pub struct BeaconHeaderRelayRunner<C: EthTruthLayerLightClient> {
+pub struct BeaconHeaderRelayRunner<C, O>
+where
+    C: EthTruthLayerLightClient,
+    O: OnDemandHeader,
+{
     pub eth_light_client: C,
     pub beacon_api_client: BeaconApiClient,
+    pub receiver: Option<Receiver<O>>,
     pub minimal_interval: u64,
     pub last_relay_time: u64,
 }
@@ -34,7 +40,11 @@ pub struct HeaderRelayState {
     pub current_period: u64,
 }
 
-impl<C: EthTruthLayerLightClient> BeaconHeaderRelayRunner<C> {
+impl<C, O> BeaconHeaderRelayRunner<C, O>
+where
+    C: EthTruthLayerLightClient,
+    O: OnDemandHeader,
+{
     pub async fn start(&mut self) -> RelayResult<()> {
         loop {
             self.run().await?;
@@ -68,8 +78,20 @@ impl<C: EthTruthLayerLightClient> BeaconHeaderRelayRunner<C> {
             "[Header] State: {:?}",
             state
         );
+
+        let finality_update: FinalityUpdate = self.beacon_api_client.get_finality_update().await?;
+        let update_finality_slot = finality_update.finalized_header.beacon.slot;
+
+        // This header has already been relayed
+        if update_finality_slot == state.relayed_slot {
+            return Ok(());
+        }
+
         if state.current_period == state.relayed_period {
-            self.relay_latest(state).await?;
+            tracing::trace!(target: "relay-e2e", "[Header] Same period");
+            if self.is_on_demand_header(update_finality_slot).await? {
+                self.relay_latest(state, finality_update).await?;
+            }
             return Ok(());
         }
 
@@ -77,9 +99,64 @@ impl<C: EthTruthLayerLightClient> BeaconHeaderRelayRunner<C> {
             return Ok(());
         }
         if state.current_period == state.relayed_period + 1 {
-            self.relay_latest(state).await
+            tracing::trace!(target: "relay-e2e", "[Header] One period behind");
+            if self.is_on_demand_header(update_finality_slot).await? {
+                self.relay_latest(state, finality_update).await
+            } else {
+                return Ok(());
+            }
         } else {
+            tracing::trace!(target: "relay-e2e", "[Header] One more period behind");
             self.relay_next_period(state).await
+        }
+    }
+
+    async fn is_on_demand_header(&mut self, update_finality_slot: u64) -> RelayResult<bool> {
+        match self.receiver.as_mut() {
+            // If there is no receiver, every finalized header will be relayed
+            None => Ok(true),
+
+            Some(receiver) => {
+                let mut required_header = None;
+                while let Ok(h) = receiver.try_recv() {
+                    required_header = Some(h);
+                }
+
+                if required_header.is_none() {
+                    tracing::trace!(
+                        target: "relay-e2e",
+                        "[Header] No signal yet",
+                    );
+                    return Ok(false);
+                }
+                let required_header = required_header.unwrap();
+
+                let update_finality_block = self
+                    .beacon_api_client
+                    .get_beacon_block(update_finality_slot)
+                    .await?;
+                let latest_block_number = update_finality_block
+                    .body()
+                    .execution_payload()?
+                    .execution_payload_capella()?
+                    .block_number;
+                tracing::info!(
+                    target: "relay-e2e",
+                    "[Header] Latest finalized slot: {:?}, finalized block number: {:?}, Required block number: {:?},",
+                    update_finality_slot,
+                    latest_block_number,
+                    required_header.block_number(),
+                );
+                if latest_block_number < required_header.block_number() {
+                    tracing::info!(
+                        target: "relay-e2e",
+                        "[Header] Wait for finalization of blocks",
+                    );
+                    return Ok(false);
+                }
+
+                Ok(true)
+            }
         }
     }
 
@@ -101,8 +178,11 @@ impl<C: EthTruthLayerLightClient> BeaconHeaderRelayRunner<C> {
         })
     }
 
-    pub async fn relay_latest(&mut self, state: HeaderRelayState) -> RelayResult<()> {
-        let finality_update: FinalityUpdate = self.beacon_api_client.get_finality_update().await?;
+    pub async fn relay_latest(
+        &mut self,
+        state: HeaderRelayState,
+        finality_update: FinalityUpdate,
+    ) -> RelayResult<()> {
         let update_finality_slot = finality_update.finalized_header.beacon.slot;
         let update_finality_period = update_finality_slot.div(32).div(256);
 
@@ -128,7 +208,9 @@ impl<C: EthTruthLayerLightClient> BeaconHeaderRelayRunner<C> {
             .get_sync_committee_period_update(update_finality_period - 1, 1)
             .await?;
         if sync_change.is_empty() {
-            return Err(RelayError::Custom("Failed to get sync committee update".into()));
+            return Err(RelayError::Custom(
+                "Failed to get sync committee update".into(),
+            ));
         }
         let fork_version = self.get_fork_version(signature_slot).await?;
         let finalized_header_update = FinalizedHeaderUpdate {
@@ -182,7 +264,9 @@ impl<C: EthTruthLayerLightClient> BeaconHeaderRelayRunner<C> {
                 .await?;
             return Ok(());
         }
-        Err(RelayError::Custom("Failed to get sync committee update".into()))
+        Err(RelayError::Custom(
+            "Failed to get sync committee update".into(),
+        ))
     }
 
     async fn get_fork_version(

--- a/assistants/relay-e2e/src/header/eth_beacon_header_relay.rs
+++ b/assistants/relay-e2e/src/header/eth_beacon_header_relay.rs
@@ -103,7 +103,7 @@ where
             if self.is_on_demand_header(update_finality_slot).await? {
                 self.relay_latest(state, finality_update).await
             } else {
-                return Ok(());
+                Ok(())
             }
         } else {
             tracing::trace!(target: "relay-e2e", "[Header] One more period behind");

--- a/assistants/relay-e2e/src/message/darwinia_message_client.rs
+++ b/assistants/relay-e2e/src/message/darwinia_message_client.rs
@@ -20,7 +20,7 @@ use web3::{
     ethabi::encode,
     signing::Key,
     transports::Http,
-    types::{Address, BlockId, BlockNumber, Bytes, H256, U256},
+    types::{Address, BlockId, BlockNumber, Bytes, U256},
     Web3,
 };
 
@@ -333,12 +333,8 @@ impl<T: RelayStrategy> MessageEventsQuery for DarwiniaMessageClient<T> {
 
     async fn query_message_dispatched(
         &self,
-        since: BlockNumber,
+        _since: BlockNumber,
     ) -> E2EClientResult<Vec<MessageDispatched>> {
-        todo!()
-    }
-
-    async fn query_all_message_dispatched(&self) -> E2EClientResult<Vec<MessageDispatched>> {
         todo!()
     }
 }

--- a/assistants/relay-e2e/src/message/ethereum_message_client.rs
+++ b/assistants/relay-e2e/src/message/ethereum_message_client.rs
@@ -431,7 +431,7 @@ impl<T: RelayStrategy> EthMessageClient<T> {
                 MessageDispatched::from_log(event.parse_log(row_log)?, block_number)
             })
             .collect::<Result<Vec<MessageDispatched>, BridgeContractError>>()?;
-        return Ok(events);
+        Ok(events)
     }
 
     pub fn build_message_storage_keys(begin: u64, end: u64) -> Vec<U256> {

--- a/assistants/relay-e2e/src/message/message_relay_runner.rs
+++ b/assistants/relay-e2e/src/message/message_relay_runner.rs
@@ -1,19 +1,21 @@
 use std::time::Duration;
 
-use bridge_e2e_traits::client::MessageClient;
+use bridge_e2e_traits::client::{MessageClient, MessageEventsQuery, OnDemandHeader};
 use client_contracts::{inbound_types::InboundLaneNonce, outbound_types::OutboundLaneNonce};
 use support_etherscan::wait_for_transaction_confirmation_with_timeout;
+use tokio::sync::broadcast::Sender;
 use web3::{
     contract::Options,
     types::{BlockId, BlockNumber, U256},
 };
 
-use crate::error::RelayResult;
+use crate::error::{RelayError, RelayResult};
 
 #[derive(Debug)]
-pub struct MessageRelayRunner<S0: MessageClient, S1: MessageClient> {
+pub struct MessageRelayRunner<S0: MessageClient, S1: MessageClient, O: OnDemandHeader> {
     pub state: ChannelState,
     pub max_message_num_per_relaying: u64,
+    pub relay_notifier: Option<Sender<O>>,
     pub source: S0,
     pub target: S1,
 }
@@ -34,10 +36,11 @@ pub struct ChannelState {
     target_block_at_source: Option<BlockNumber>,
 }
 
-impl<S0, S1> MessageRelayRunner<S0, S1>
+impl<S0, S1, O> MessageRelayRunner<S0, S1, O>
 where
-    S0: MessageClient,
+    S0: MessageClient + MessageEventsQuery,
     S1: MessageClient,
+    O: OnDemandHeader,
 {
     pub async fn update_channel_state(&mut self) -> RelayResult<()> {
         let target_inbound = self.target.inbound().inbound_lane_nonce(None).await?;
@@ -88,6 +91,13 @@ where
             return Ok(());
         }
 
+        let (begin, end) = (
+            self.state.source_outbound.latest_received_nonce + 1,
+            self.state.source_outbound.latest_generated_nonce,
+        );
+        self.delivery_notify_on_demand_header(self.state.target_inbound.last_delivered_nonce + 1)
+            .await?;
+
         match self.state.source_block_at_target {
             None => {
                 tracing::info!(
@@ -98,11 +108,6 @@ where
             }
             Some(num) => num,
         };
-
-        let (begin, end) = (
-            self.state.source_outbound.latest_received_nonce + 1,
-            self.state.source_outbound.latest_generated_nonce,
-        );
 
         if self.state.target_inbound.last_delivered_nonce
             >= self.state.source_outbound_relayed.latest_generated_nonce
@@ -224,7 +229,7 @@ where
             self.target.get_web3().transport(),
             Duration::from_secs(5),
             1,
-            150
+            150,
         )
         .await?;
 
@@ -318,10 +323,41 @@ where
             self.source.get_web3().transport(),
             Duration::from_secs(5),
             1,
-            150
+            150,
         )
         .await?;
 
+        Ok(())
+    }
+
+    async fn delivery_notify_on_demand_header(&mut self, nonce: u64) -> RelayResult<()> {
+        if let Some(s) = self.relay_notifier.as_ref() {
+            let event = self.source.query_message_accepted(nonce).await?;
+            if event.is_none() {
+                return Ok(());
+            }
+
+            let event = event.unwrap();
+            if s.len() > 0 {
+                tracing::info!(
+                    target: "relay-e2e",
+                    "[MessageTunnel][{}=>{}] Tunnel length: {:?}, required header: {:?}, ...",
+                    self.source.chain(),
+                    self.target.chain(),
+                    s.len(),
+                    event.block_number,
+                );
+                return RelayResult::Ok(());
+            }
+            s.send(event.block_number.into())
+                .map_err(|_| RelayError::Custom("Tunnel error".into()))?;
+            tracing::info!(
+                target: "relay-e2e",
+                "[MessageTunnel][{}=>{}] Sending header-required signal",
+                self.source.chain(),
+                self.target.chain(),
+            );
+        }
         Ok(())
     }
 }

--- a/assistants/relay-e2e/src/message/message_relay_runner.rs
+++ b/assistants/relay-e2e/src/message/message_relay_runner.rs
@@ -362,7 +362,7 @@ where
                 return Ok(());
             }
             let event = events.first().expect("Unreachable!");
-            if s.len() > 0 {
+            if !s.is_empty() {
                 tracing::trace!(
                     target: "relay-e2e",
                     "[MessageConfirmation][{}=>{}] Tunnel length: {:?}, required header: {:?}",
@@ -395,7 +395,7 @@ where
             }
 
             let event = event.unwrap();
-            if s.len() > 0 {
+            if !s.is_empty() {
                 tracing::trace!(
                     target: "relay-e2e",
                     "[MessageDelivery][{}=>{}] Tunnel length: {:?}, required header: {:?}",

--- a/traits/bridge-e2e/src/client.rs
+++ b/traits/bridge-e2e/src/client.rs
@@ -120,9 +120,6 @@ pub trait MessageEventsQuery {
 
     // Query MessageDispatched events from inbound contract since a block number
     async fn query_message_dispatched(&self, since: BlockNumber) -> E2EClientResult<Vec<MessageDispatched>>;
-
-    // Query all MessageDispatched events at cold start
-    async fn query_all_message_dispatched(&self) -> E2EClientResult<Vec<MessageDispatched>>;
 }
 
 pub trait OnDemandHeader: Clone + From<u64> {

--- a/traits/bridge-e2e/src/client.rs
+++ b/traits/bridge-e2e/src/client.rs
@@ -1,7 +1,8 @@
 use std::cmp;
 use std::fmt::Debug;
 
-use client_contracts::outbound_types::ReceiveMessagesDeliveryProof;
+use client_contracts::inbound_types::MessageDispatched;
+use client_contracts::outbound_types::{ReceiveMessagesDeliveryProof, MessageAccepted};
 use client_contracts::BeaconLightClient;
 use client_contracts::{inbound_types::ReceiveMessagesProof, Inbound, Outbound};
 use secp256k1::SecretKey;
@@ -110,4 +111,20 @@ pub trait MessageClient: GasPriceOracle {
 
     // Returns latest block number of the light client of the other chain
     async fn latest_light_client_block_number(&self) -> E2EClientResult<Option<u64>>;
+}
+
+#[async_trait::async_trait]
+pub trait MessageEventsQuery {
+    // Query MessageAccepted events from outbound contract
+    async fn query_message_accepted(&self, nonce: u64) -> E2EClientResult<Option<MessageAccepted>>;
+
+    // Query MessageDispatched events from inbound contract since a block number
+    async fn query_message_dispatched(&self, since: BlockNumber) -> E2EClientResult<Vec<MessageDispatched>>;
+
+    // Query all MessageDispatched events at cold start
+    async fn query_all_message_dispatched(&self) -> E2EClientResult<Vec<MessageDispatched>>;
+}
+
+pub trait OnDemandHeader: Clone + From<u64> {
+   fn block_number(&self) -> u64;
 }


### PR DESCRIPTION
Change the strategy of Eth header relay:
- The header will be relayed from Ethereum to Darwinia when the message delivery or confirmation services notify it.
- If there are no messages needed to relay, header relay service will work only once every period(32*256 blocks)

Tests:
- Eth light client contract on Pangolin: https://pangolin.subscan.io/evm_transaction?block=0x9Ca2b190d84E635F131060319FACc943b0653680&page=1

Relayer account:
 1. https://goerli.etherscan.io/address/0x573749FFee40b3aA6C080144D4071847c51B5C33
 2. https://goerli.etherscan.io/address/0xa4A07c23C6e3b3835DC760563E898143c23704Ae